### PR TITLE
166 inputtextvue komponente erweitern

### DIFF
--- a/src/components/input-elements/Button.vue
+++ b/src/components/input-elements/Button.vue
@@ -43,8 +43,8 @@ export default {};
   color: var(--primary-light);
 }
 
-.disabled {
-  pointer-events: none;
+.Log-btn:disabled {
+  pointer-events: not-allowed;
   color: var(--font-disabled);
   border-color: var(--font-disabled);
 }

--- a/src/components/input-elements/InputText.vue
+++ b/src/components/input-elements/InputText.vue
@@ -159,27 +159,27 @@ export default {
     giveHelperText() {
       switch (this.inputType) {
         case "text":
-          return "Hier kannst du einen beliebigen Freitext eingeben. Tob dich aus!";
+          return "Gib hier Deinen Usernamen ein. Es gibt nur eine Auflage: Du musst ihn Dir merken können.";
         case "email":
-          return "Bitte gib deine Mail Adresse an. Die sollte in etwa so aussehen meinKuerzel@provider.com";
+          return "Bitte gib hier deine Mail-Adresse an. Sie sollte in etwa so aussehen: meinKuerzel@provider.com";
         case "password":
-          return "Ein sicheres Password für dich sollte mindestens 12 Zeichen haben. Benutze am besten eine Mischung aus Groß-, Kleinschreibung mit Sonderzeichen und Zahlen.";
+          return "Ein sicheres Passwort hat mindestens 12 Zeichen. Benutze hierbei bitte eine Mischung aus Groß-, Kleinschreibung, Sonderzeichen und Zahlen.";
         case "datetime-local":
           return "Wähle einfach das passende Datum und die Zeit aus.";
         default:
-          return "Da ist wohl was schief gelaufen?! Hierfür haben wir gerade kein Hilfetext parat.";
+          return "Da ist wohl was schief gelaufen?! Hierfür haben wir gerade keinen Hilfetext parat. Sollte das Problem noch einmal auftreten, kontaktiere uns unter 'capp.carsharing@gmail.com'.";
       }
     },
     invalidMessage() {
       switch (this.inputType) {
         case "text":
-          return "Der Freitext ist nicht valide";
+          return "Der Username ist nicht korrekt";
         case "email":
-          return "Die Mail adresse ist nicht valide.";
+          return "Die Mail-Adresse ist nicht korrekt.";
         case "password":
-          return "Passwort Kriterien nicht erfüllt";
+          return "Leider wurden die Passwort-Kriterien nicht erfüllt";
         default:
-          return "Da ist wohl was schief gelaufen?! Hierfür haben wir gerade kein Hilfetext parad.";
+          return "Da ist wohl was schief gelaufen?! Hierfür haben wir gerade keinen Hilfetext parat. Sollte das Problem noch einmal auftreten, kontaktiere uns unter 'capp.carsharing@gmail.com'.";
       }
     },
   },

--- a/src/components/input-elements/InputText.vue
+++ b/src/components/input-elements/InputText.vue
@@ -80,7 +80,7 @@
         autocomplete="on"
         required
       />
-      <p
+      <p v-if="isInValid"
         class="capp-input__invalid-input"
         :class="{ input__valid: isValid, input__invalid: isInValid }"
       >
@@ -105,7 +105,7 @@
 
       <!-- Start: Help/Question Information Text -->
       <Transition>
-        <article class="capp-input__help" v-show="showHelp">
+        <article class="capp-input__help" v-if="showHelp">
           <p>{{ giveHelperText }}</p>
         </article>
       </Transition>
@@ -128,7 +128,7 @@ export default {
       validator(value) {
         // Only input Element type specific names are allowed
         // List can be extented if needed
-        return ["text", "email", "password"].includes(value);
+        return ["text", "email", "password", "datetime-local"].includes(value);
       },
     },
     inputPlaceholder: {
@@ -155,7 +155,9 @@ export default {
           return "Bitte gib deine Mail Adresse an. Die sollte in etwa so aussehen meinKuerzel@provider.com";
         case "password":
           return "Ein sicheres Password für dich sollte mindestens 12 Zeichen haben. Benutze am besten eine Mischung aus Groß-, Kleinschreibung mit Sonderzeichen und Zahlen.";
-        default:
+        case "datetime-local":
+          return "Wähle einfach das passende Datum und die Zeit aus."
+          default:
           return "Da ist wohl was schief gelaufen?! Hierfür haben wir gerade kein Hilfetext parat.";
       }
     },

--- a/src/components/input-elements/InputText.vue
+++ b/src/components/input-elements/InputText.vue
@@ -20,7 +20,10 @@
     > -->
 
 <!-- Hier wurde als Beispiel der slot mit dem default Text überschrieben mit "Another Mail"-->
+<!-- Zudem wurde ein v-model verwendet. Das muss immer mit v-model:inputData geschrieben werden,-->
+<!-- danach kannst du eine einen namen verwenden den du in data() festgelegt hast.-->
 <!-- <InputText
+      v-model:inputData="yourDataName"
       :inputId="'another-mail'"
       :inputType="'email'"
       :inputPlaceholder="'dontTrust@Rabbits.com'"
@@ -81,7 +84,8 @@
         autocomplete="on"
         required
       />
-      <p v-if="isInValid"
+      <p
+        v-if="isInValid"
         class="capp-input__invalid-input"
         :class="{ input__valid: isValid, input__invalid: isInValid }"
       >
@@ -161,8 +165,8 @@ export default {
         case "password":
           return "Ein sicheres Password für dich sollte mindestens 12 Zeichen haben. Benutze am besten eine Mischung aus Groß-, Kleinschreibung mit Sonderzeichen und Zahlen.";
         case "datetime-local":
-          return "Wähle einfach das passende Datum und die Zeit aus."
-          default:
+          return "Wähle einfach das passende Datum und die Zeit aus.";
+        default:
           return "Da ist wohl was schief gelaufen?! Hierfür haben wir gerade kein Hilfetext parat.";
       }
     },

--- a/src/components/input-elements/SelectDropDown.vue
+++ b/src/components/input-elements/SelectDropDown.vue
@@ -1,20 +1,108 @@
+<!-- ================================================== -->
+<!-- ========= Einführung in diese Komponente ========= -->
+<!-- ================================================== -->
+
+<!-- Die Select Komponente benötigt mindestens eine :selectId-->
+<!-- Zudem benötigt es noch ein v-model:selectedData="AusgewählteDatei" -->
+<!-- Deine "AusgewählteDatei" kannst du in data() auffangen -->
+<!-- Um der Select Komponent daten zu geben musst du :givenData="DataPackage" mit deinen Daten befüllen  -->
+<!-- Ein Datenpacket kann ein enum sein (mit nur einer Daten Spalte) wie "fuel_type" oder "category"-->
+<!-- Oder auch zwei Spaltige Daten mit Id und name wie "purpose" oder "brands" -->
+
+<!-- Das ist ein beispiel wie man DatenPackete mit zwei Spalten aus Supabase holt -->
+<!-- async getPurposes() {
+  try {
+    const { data, error } = await supabase.from("purposes").select();
+    if (error) throw error;
+    if (data) {
+      this.purposeData = data;
+    }
+  } catch (error) {
+    alert(error.message);
+  }
+}, -->
+<!-- Bei enum Werten muss man allerdings das etwas anders machen:-->
+<!-- async getCategorys() {
+  try {
+    const { data, error } = await supabase.rpc("get_category");
+
+    if (error) throw error;
+
+    if (data) {
+      this.categoryData = data;
+    }
+  } catch (error) {
+    alert(error.message);
+  }
+}, -->
+<!-- mit .rpc() kann man eine Supabase Funktion aufrufen die man davor erstellen muss -->
+<!-- Folgende Funktionen wurden bereits erstellt und können genutzt werden: -->
+<!-- get_category -->
+<!-- get_fuel -->
+<!-- get_gear -->
+<!-- get_insurance -->
+<!-- get_route_status -->
+
+<!-- Hier ein Beispiel wie eine Komponente Aussehen könnte -->
+<!-- <SelectDropDown
+        v-model:selectedData="purposeSelected"
+        :selectId="'select-purpose'"
+        :givenData="purposeData"
+        :defaultText="'Klicke auf mich und wähle deinen Grund aus.'"
+        :isRequired="true"
+      >
+        Dein Grund fürs Ausleihen</SelectDropDown -->
+
 <template>
   <div class="capp-input__wrapper">
-    <label class="capp-label__default" :for="selectId">Template</label>
-    <select
-      class="capp-input__default"
-      :name="selectId"
-      :id="selectId"
-      :value="selectedData"
-      @input="$emit('update:selectedData', $event.target.value)"
-      :required="isRequired"
-    >
-      <!-- puropse_name and id are not flexibel. Here you need to adjust! -->
-      <option disabled value="">--For what do you need the car?</option>
-      <option v-for="item in givenData" :value="item.id" :key="item.id">
-        {{ item.purpose_name }}
-      </option>
-    </select>
+    <span>
+      <label class="capp-label__default" :for="selectId">
+        <slot>Drop Down Menu</slot>
+      </label>
+      <select
+        class="capp-input__default"
+        :name="selectId"
+        :id="selectId"
+        :value="selectedData"
+        @input="$emit('update:selectedData', $event.target.value)"
+        :required="isRequired"
+      >
+        <option disabled value="">{{ defaultText }}</option>
+        <option v-for="name in givenData" :value="name.id" :key="name.id">
+          <p v-if="multiColumn">
+            {{ Object.values(name)[1] }}
+          </p>
+          <p v-else>
+            {{ name }}
+          </p>
+        </option>
+      </select>
+      {{ multiColumn }}
+    </span>
+    <div class="capp-input__help-wrapper">
+      <!-- Start: Help/Question Button -->
+      <button class="capp-input__btn" @click.prevent="showHelp = !showHelp">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="currentColor"
+          class="bi bi-question-circle-fill"
+          viewBox="0 0 16 16"
+        >
+          <path
+            d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z"
+          />
+        </svg>
+      </button>
+      <!-- End: Help/Question Button -->
+
+      <!-- Start: Help/Question Information Text -->
+      <Transition>
+        <article class="capp-input__help" v-if="showHelp">
+          <p>Klicke auf das Dropdown Menü und mache dein Auswahl</p>
+        </article>
+      </Transition>
+      <!-- End: Help/Question Information Text -->
+    </div>
   </div>
 </template>
 
@@ -34,6 +122,10 @@ export default {
     givenData: {
       type: Array,
     },
+    defaultText: {
+      type: String,
+      default: "--For what do you need the car?",
+    },
     isRequired: {
       type: Boolean,
       default: false,
@@ -41,9 +133,111 @@ export default {
   },
   emits: ["update:selectedData"],
   data() {
-    return {};
+    return {
+      multiColumn: null,
+      testvalue: "brand_name",
+      showHelp: false,
+    };
+  },
+  methods: {
+    givenDataCorrection() {
+      this.givenData.filter((item) => {
+        if (item.id !== undefined) {
+          this.multiColumn = true;
+        } else {
+          this.multiColumn = false;
+        }
+      });
+    },
+  },
+  beforeUpdate() {
+    this.givenDataCorrection();
   },
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+.capp-input__wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  gap: 1rem;
+}
+.capp-input__wrapper span {
+  width: 100%;
+}
+.capp-label__default {
+  display: block;
+  color: var(--primary-dark);
+
+  padding-block: calc(var(--s-font) / 2);
+  font-size: 1.5rem;
+  letter-spacing: 0.1rem;
+}
+
+.capp-input__default {
+  display: block;
+  width: 100%;
+  border: 2px solid var(--clr-trans);
+  border-radius: 0.5rem;
+  padding-inline: 0.5rem;
+  padding-block: 1rem;
+  font-size: var(--m-font);
+  background: var(--clr-bg-main);
+  box-shadow: inset 0 5px 5px -2px var(--secondary-dark);
+  color: var(--font-color-dark);
+}
+.capp-input__default:hover {
+  cursor: pointer;
+}
+.capp-input__default::placeholder {
+  opacity: 0.5;
+}
+
+.capp-input__default:focus {
+  outline-color: var(--primary-light);
+}
+.capp-input__help-wrapper {
+  position: relative;
+}
+.capp-input__btn {
+  all: unset;
+  width: calc(var(--s-font) * 2);
+  aspect-ratio: 1;
+}
+.capp-input__btn:active > svg {
+  fill: var(--primary-mid);
+}
+.capp-input__btn svg {
+  fill: var(--secondary-default);
+  position: relative;
+}
+
+.capp-input__help {
+  position: absolute;
+  top: 20p;
+  left: 0;
+  display: block;
+  font-size: 1.2rem;
+  background: var(--secondary-light);
+  border: 1px solid var(--primary-dark);
+  border-radius: 1rem;
+  width: 20rem;
+  height: auto;
+  padding: 1rem;
+  text-align: start;
+  z-index: 10;
+}
+/*=================Helper Text show/hide Transition (works with <Transition> from vue) =================*/
+
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 0.5s ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/components/input-elements/SelectDropDown.vue
+++ b/src/components/input-elements/SelectDropDown.vue
@@ -98,7 +98,7 @@
       <!-- Start: Help/Question Information Text -->
       <Transition>
         <article class="capp-input__help" v-if="showHelp">
-          <p>Klicke auf das Dropdown Menü und mache dein Auswahl</p>
+          <p>Klicke auf das Dropdown-Menü und triff Deine Auswahl</p>
         </article>
       </Transition>
       <!-- End: Help/Question Information Text -->

--- a/src/components/input-elements/SelectDropDown.vue
+++ b/src/components/input-elements/SelectDropDown.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="capp-input__wrapper">
+    <label class="capp-label__default" :for="selectId">Template</label>
+    <select
+      class="capp-input__default"
+      :name="selectId"
+      :id="selectId"
+      :value="selectedData"
+      @input="$emit('update:selectedData', $event.target.value)"
+      :required="isRequired"
+    >
+      <!-- puropse_name and id are not flexibel. Here you need to adjust! -->
+      <option disabled value="">--For what do you need the car?</option>
+      <option v-for="item in givenData" :value="item.id" :key="item.id">
+        {{ item.purpose_name }}
+      </option>
+    </select>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "SelectDropDown",
+  props: {
+    selectId: {
+      type: String,
+      default: "dropdown",
+      required: true,
+    },
+    selectedData: {
+      type: String,
+      default: null,
+    },
+    givenData: {
+      type: Array,
+    },
+    isRequired: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["update:selectedData"],
+  data() {
+    return {};
+  },
+};
+</script>
+
+<style scoped></style>

--- a/src/components/input-elements/TextArea.vue
+++ b/src/components/input-elements/TextArea.vue
@@ -1,11 +1,13 @@
 <template>
   <div class="text-wrapper">
     <textarea
-      name=""
-      id=""
-      cols="30"
-      rows="10"
-      placeholder="Sende eine Nachricht ..."
+      :name="name"
+      :id="id"
+      :cols="cols"
+      :rows="rows"
+      :placeholder="placeholder"
+      :value="inputData"
+      @input="$emit('update:inputData', $event.target.value)"
     ></textarea>
     <Messagebutton class="send-button" />
   </div>
@@ -14,6 +16,32 @@
 <script>
 import Messagebutton from "@/components/input-elements/Button.vue";
 export default {
+  name: "TextArea",
+  emits: ["update:inputData"],
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+    },
+    placeholder: {
+      type: String,
+      default: "Sende eine Nachricht ...",
+    },
+    cols: {
+      type: String,
+      default: "30",
+    },
+    rows: {
+      type: String,
+      default: "10",
+    },
+    inputData: {
+      type: String,
+    },
+  },
   components: {
     Messagebutton,
   },

--- a/src/views/DanielsView.vue
+++ b/src/views/DanielsView.vue
@@ -32,7 +32,12 @@
         >Password</InputText
       >
 
-      <InputText :inputType="'datetime-local'" :inputId="'start-period'">Start Date/Time</InputText>
+      <InputText
+        v-model:inputData="test"
+        :inputType="'datetime-local'"
+        :inputId="'start-period'"
+        >Start Date/Time</InputText
+      >
     </form>
     <!-- Test von Pinia mit der Option API -->
     <!-- <button @click.prevent="getUser()">Get new State</button>
@@ -40,6 +45,7 @@
       {{ users }}
     </pre> -->
   </div>
+  <p>{{ test }}</p>
 </template>
 
 <script>
@@ -50,6 +56,11 @@ import { userStateStore } from "@/stores/userStateStorage";
 import { mapState, mapActions } from "pinia";
 
 export default {
+  data() {
+    return {
+      test: null,
+    };
+  },
   components: { InputText },
   // Die Actions von Pina werden mit den methods ausgeführt in der Option API
   methods: {

--- a/src/views/DanielsView.vue
+++ b/src/views/DanielsView.vue
@@ -31,12 +31,14 @@
       <InputText :inputId="'first-password'" :inputType="'password'"
         >Password</InputText
       >
+
+      <InputText :inputType="'datetime-local'" :inputId="'start-period'">Start Date/Time</InputText>
     </form>
     <!-- Test von Pinia mit der Option API -->
-    <button @click.prevent="getUser()">Get new State</button>
+    <!-- <button @click.prevent="getUser()">Get new State</button>
     <pre>
       {{ users }}
-    </pre>
+    </pre> -->
   </div>
 </template>
 

--- a/src/views/DanielsView.vue
+++ b/src/views/DanielsView.vue
@@ -38,6 +38,12 @@
         :inputId="'start-period'"
         >Start Date/Time</InputText
       >
+      <SelectDropDown
+        v-model:selectedData="purposeSelected"
+        :selectId="'select-purpose'"
+        :givenData="purposeData"
+      ></SelectDropDown>
+      {{ purposeSelected }}
     </form>
     <!-- Test von Pinia mit der Option API -->
     <!-- <button @click.prevent="getUser()">Get new State</button>
@@ -50,6 +56,8 @@
 
 <script>
 import InputText from "@/components/input-elements/InputText.vue";
+import SelectDropDown from "@/components/input-elements/SelectDropDown.vue";
+import { supabase } from "@/lib/supabaseClient.js";
 // Holt uns den passenden Store
 import { userStateStore } from "@/stores/userStateStorage";
 // mapState und mapActions sind teile der Pinia Options API
@@ -59,9 +67,11 @@ export default {
   data() {
     return {
       test: null,
+      purposeSelected: null,
+      purposeData: null,
     };
   },
-  components: { InputText },
+  components: { InputText, SelectDropDown },
   // Die Actions von Pina werden mit den methods ausgeführt in der Option API
   methods: {
     ...mapActions(userStateStore, { getUser: "getUser" }),
@@ -70,6 +80,22 @@ export default {
   // Kann auch anders genutzt werden z.B. data()...
   computed: {
     ...mapState(userStateStore, ["users"]),
+  },
+  mounted() {
+    this.getPurposes();
+  },
+  methods: {
+    async getPurposes() {
+      try {
+        const { data, error } = await supabase.from("purposes").select();
+        if (error) throw error;
+        if (data) {
+          this.purposeData = data;
+        }
+      } catch (error) {
+        alert(error.message);
+      }
+    },
   },
 };
 </script>

--- a/src/views/DanielsView.vue
+++ b/src/views/DanielsView.vue
@@ -42,14 +42,33 @@
         v-model:selectedData="purposeSelected"
         :selectId="'select-purpose'"
         :givenData="purposeData"
-      ></SelectDropDown>
+        :defaultText="'Klicke auf mich und wähle deinen Grund aus.'"
+        :isRequired="true"
+      >
+        Dein Grund fürs Ausleihen</SelectDropDown
+      >
       {{ purposeSelected }}
+      <pre>
+        {{ categoryData }}
+      </pre>
+      <SelectDropDown
+        v-model:selectedData="selectedData"
+        :selectId="'select-category'"
+        :givenData="categoryData"
+        :defaultText="'Wähle deine Kategorie'"
+      ></SelectDropDown>
+
+      {{ selectedData }}
+      <TextArea
+        v-model:inputData="textMsg"
+        id="my-test-text"
+        name="my-test-text"
+        placeholder="Bitte schreiben..."
+        cols="5"
+        rows="5"
+      ></TextArea>
+      {{ textMsg }}
     </form>
-    <!-- Test von Pinia mit der Option API -->
-    <!-- <button @click.prevent="getUser()">Get new State</button>
-    <pre>
-      {{ users }}
-    </pre> -->
   </div>
   <p>{{ test }}</p>
 </template>
@@ -57,6 +76,7 @@
 <script>
 import InputText from "@/components/input-elements/InputText.vue";
 import SelectDropDown from "@/components/input-elements/SelectDropDown.vue";
+import TextArea from "@/components/input-elements/TextArea.vue";
 import { supabase } from "@/lib/supabaseClient.js";
 // Holt uns den passenden Store
 import { userStateStore } from "@/stores/userStateStorage";
@@ -69,9 +89,12 @@ export default {
       test: null,
       purposeSelected: null,
       purposeData: null,
+      categoryData: null,
+      selectedData: null,
+      textMsg: null,
     };
   },
-  components: { InputText, SelectDropDown },
+  components: { InputText, SelectDropDown, TextArea },
   // Die Actions von Pina werden mit den methods ausgeführt in der Option API
   methods: {
     ...mapActions(userStateStore, { getUser: "getUser" }),
@@ -81,8 +104,9 @@ export default {
   computed: {
     ...mapState(userStateStore, ["users"]),
   },
-  mounted() {
+  created() {
     this.getPurposes();
+    this.getCategorys();
   },
   methods: {
     async getPurposes() {
@@ -91,6 +115,19 @@ export default {
         if (error) throw error;
         if (data) {
           this.purposeData = data;
+        }
+      } catch (error) {
+        alert(error.message);
+      }
+    },
+    async getCategorys() {
+      try {
+        const { data, error } = await supabase.rpc("get_category");
+
+        if (error) throw error;
+
+        if (data) {
+          this.categoryData = data;
         }
       } catch (error) {
         alert(error.message);


### PR DESCRIPTION
Solves #166 

### Folgende Punkte sind neu oder wurden modifiziert

- InputText.vue erkennt nun auch den  typ="'datetime-local'", zudem wurde der Erklärungstext leicht verändert um v-model Nutzung zu erklären.
![image](https://github.com/danielkull/capp/assets/119632155/7dabcae1-7bf9-48e4-ba8b-e6508df6cefb)

- Es wurde eine neue SelectDropDown.vue Komponente erstellt. Dies kann mit Daten Paketen gefüttert werden. Heißt Zwei Spaltige Datenbank Tabellen wie Brands oder Purpose können geladen werden. Zudem kann die Komponente auch erkennen ob es nur eine Spalte ohne Id ist, das macht es möglich auch enum wie Kategory oder Gear zu laden.
- Auch hier gibt es eine v-model funktion. Bei zwei Spaltigen Datensätzen bekommt man die ID, bei einspaltigen dann nur den Namen.
- Die Beschreibung umfasst nicht nur die Nutzung der Komponente sondern auch wie man mit Supabase die jeweiligen Daten abruft. Für die Enum Abfragen wurden eigens Postgres Funktionen gebaut die man benutzen kann.

![image](https://github.com/danielkull/capp/assets/119632155/3751c680-1f59-48a5-9400-a215c6f7cdef)

- Die Button.vue Komponente wurde etwas modifiziert. Die Classe "disabled ist nun eine Pseudo-classe. Damit kann man beim Button mit true or false den Stand verändern:
```vue
<Button
      @click="logOut"
      :value="loading ? 'Loading...' : 'Log Out'"
      :disabled="loading"
      class="btn-abstand"
    ></Button>
``` 

- Die TextArea.vue Komponente wurde etws modifiziert. Es ist nun möglich variable Eigenschaften wie id, name, cols, rows, placeholder außerhalb, für die jeweilige Komponente, zu definieren. Zudem funktioniert v-model.
