### PR TITLE
87 text eingabefelder im fragebogen durch inputtext component ersetzen

### DIFF
--- a/src/components/FilterDropDown.vue
+++ b/src/components/FilterDropDown.vue
@@ -306,7 +306,7 @@ export default {
       h2filterCarType: "Auto-Typen",
       h2filterFuelType: "Treibstoff-Arten",
       h2filterGears: "Getriebe-Art",
-      h2filterTrunkSize: "Kofferaum-Größe",
+      h2filterTrunkSize: "Kofferraum-Größe",
       h2filterSeats: "Anzahl an freien Sitzen",
       h2features: "Ausstattung",
       h2smoker: "Raucher oder Nichtraucher?",
@@ -726,8 +726,12 @@ ul.question-list {
 }
 
 label {
-  font-size: 1.1rem;
-  color: var(--font-color-light);
+  _font-size: 1.1rem;
+  _color: var(--font-color-light);
+  color: var(--primary-dark);
+  padding-block: calc(var(--s-font) / 2);
+  font-size: 1.15rem;
+  letter-spacing: 0.1rem;
 }
 
 label > img {

--- a/src/components/UserQuestionMenue.vue
+++ b/src/components/UserQuestionMenue.vue
@@ -271,20 +271,7 @@
               />
               <label :for="`feature-${feature.id}`">{{ feature.name }}</label>
             </li>
-            <!-- Sonstiges 
-            <li class="question-list__item">
-              <p>&nbsp;</p>
-              <label for="misc">Sonstiges</label>
-              <input
-                type="text"
-                class="capp-input__default"
-                name="misc"
-                id="misc"
-                v-model="miscellaneous"
-                placeholder="Sonstiges"
-              />
-            </li>
-            -->
+            <!-- Sonstiges -->
             <input-text
               :inputId="'misc'"
               :inputType="'text'"
@@ -307,40 +294,43 @@
           h2textTrunkSize
         }}</label>
         <section class="question-list__list">
-          <ul class="question-list">
-            <li
-              class="question-list__item"
-              v-for="luggageTrunkSize in luggageTrunkSizes"
-              :key="luggageTrunkSize.id"
-            >
-              <input
-                class="capp-radio__default"
-                type="radio"
-                name="trunk-size"
-                :id="luggageTrunkSize.id"
-                :value="[
-                  luggageTrunkSize.id,
-                  luggageTrunkSize.min,
-                  luggageTrunkSize.max,
-                ]"
-                v-model="chosenTrunkSize"
-              />
-              <label :for="luggageTrunkSize.id"
-                >{{ luggageTrunkSize.id }} {{ luggageTrunkSize.min }}-{{
-                  luggageTrunkSize.max
-                }}
-                Liter</label
+          <div>
+            <p>&nbsp;</p>
+            <ul class="question-list">
+              <li
+                class="question-list__item"
+                v-for="luggageTrunkSize in luggageTrunkSizes"
+                :key="luggageTrunkSize.id"
               >
-            </li>
-            <!-- Eigene Angaben -->
-            <input-text
-              :inputId="'own-trunk-size'"
-              :inputType="'text'"
-              :inputPlaceholder="'Eigene Angaben'"
-              v-model:inputData="ownTrunkSize"
-              >Eigene Angaben</input-text
-            >
-          </ul>
+                <input
+                  class="capp-radio__default"
+                  type="radio"
+                  name="trunk-size"
+                  :id="luggageTrunkSize.id"
+                  :value="[
+                    luggageTrunkSize.id,
+                    luggageTrunkSize.min,
+                    luggageTrunkSize.max,
+                  ]"
+                  v-model="chosenTrunkSize"
+                />
+                <label :for="luggageTrunkSize.id"
+                  >{{ luggageTrunkSize.id }} {{ luggageTrunkSize.min }}-{{
+                    luggageTrunkSize.max
+                  }}
+                  Liter</label
+                >
+              </li>
+              <!-- Eigene Angaben -->
+              <input-text
+                :inputId="'own-trunk-size'"
+                :inputType="'text'"
+                :inputPlaceholder="'Eigene Angaben'"
+                v-model:inputData="ownTrunkSize"
+                >Eigene Angaben</input-text
+              >
+            </ul>
+          </div>
         </section>
       </article>
       <!------------------------------------------------------------>
@@ -378,9 +368,16 @@
                   {{ limitation.name }}</label
                 >
               </li>
-              <li class="question-list__item">
-                <label for="min-age">Mindestalter</label>
-                <select name="min-age" id="min-age" v-model="chosenMinAge">
+              <li class="question-list__item capp-input__wrapper">
+                <label for="min-age" class="capp-label__default"
+                  >Mindestalter</label
+                >
+                <select
+                  class="capp-select__default"
+                  name="min-age"
+                  id="min-age"
+                  v-model="chosenMinAge"
+                >
                   <option
                     v-for="minAge in minAges"
                     :key="minAge.id"
@@ -762,6 +759,7 @@ ul.question-list {
   list-style-type: none;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 0.75rem;
 }
 
 .padding-top {
@@ -818,8 +816,12 @@ ul.question-list {
 }
 
 label {
-  font-size: 1.1rem;
-  color: var(--font-color-light);
+  _font-size: 1.1rem;
+  _color: var(--font-color-light);
+  color: var(--primary-dark);
+  padding-block: calc(var(--s-font) / 2);
+  font-size: 1.15rem;
+  letter-spacing: 0.1rem;
 }
 
 label > img {
@@ -980,5 +982,27 @@ select {
 
 select:focus-within {
   outline-color: var(--primary-mid);
+}
+
+.capp-label__default {
+  display: block;
+  color: var(--primary-dark);
+
+  padding-block: calc(var(--s-font) / 2);
+  font-size: 1.5rem;
+  letter-spacing: 0.1rem;
+}
+
+.capp-select__default {
+  display: block;
+  width: 100%;
+  border: 2px solid var(--clr-trans);
+  border-radius: 0.5rem;
+  padding-inline: 0.5rem;
+  padding-block: 1rem;
+  font-size: var(--m-font);
+  background: var(--clr-bg-main);
+  box-shadow: inset 0 5px 5px -2px var(--secondary-dark);
+  color: var(--font-color-dark);
 }
 </style>

--- a/src/components/UserQuestionMenue.vue
+++ b/src/components/UserQuestionMenue.vue
@@ -22,161 +22,78 @@
         }}</label>
         <section class="question-list__list">
           <ul class="question-list">
-            <li class="question-list__item personal-item">
-              <label for="username">Nickname</label>
-              <input
-                type="text"
-                class="capp-input__default"
-                name="username"
-                id="username"
-                placeholder="Username"
-                v-model="usernameValue"
-                :class="{
-                  input__invalid:
-                    usernameValue.length > 0 && usernameValue.length < 5,
-                }"
-              />
-              <span>Muss mindestens 5 Zeichen enthalten.</span>
-            </li>
-            <li class="question-list__item personal-item">
-              <label for="password"
-                >Passwort&nbsp;<span
-                  id="password-toggle-text"
-                  @click="togglePassword()"
-                  >&lt;{{ inputTypeText }}&gt;</span
-                ></label
-              >
-              <input
-                :type="inputType"
-                class="capp-input__default"
-                name="password"
-                id="password"
-                v-model="passwordValue"
-                :class="{
-                  input__invalid:
-                    passwordValue.length > 0 && passwordValue.length < 10,
-                }"
-              />
-              <span>Muss mindestens 10 Zeichen enthalten.</span>
-            </li>
-            <li class="question-list__item personal-item">
-              <label for="firstname">Vorname</label>
-              <input
-                type="text"
-                class="capp-input__default"
-                name="firstname"
-                id="firstname"
-                placeholder="Vorname"
-                v-model="firstnameValue"
-                :class="{
-                  input__invalid:
-                    firstnameValue.length === 1 ||
-                    /[0-9!?§$%&(){}€@#]/.test(firstnameValue),
-                }"
-              />
-              <span
-                >Muss mindestens 2 Zeichen, darf keine Ziffern oder
-                Sonderzeichen enthalten.</span
-              >
-            </li>
-            <li class="question-list__item personal-item">
-              <label for="lastname">Nachname</label>
-              <input
-                type="text"
-                class="capp-input__default"
-                name="lastname"
-                id="lastname"
-                placeholder="Nachname"
-                v-model="lastnameValue"
-                :class="{
-                  input__invalid:
-                    lastnameValue.length === 1 ||
-                    /[0-9!?§$%&(){}€@#]/.test(lastnameValue),
-                }"
-              />
-              <span
-                >Muss mindestens 2 Zeichen, darf keine Ziffern oder
-                Sonderzeichen enthalten.</span
-              >
-            </li>
-            <li class="question-list__item personal-item">
-              <label for="email">E-Mail</label>
-              <input
-                type="email"
-                class="capp-input__default"
-                name="email"
-                id="email"
-                placeholder="E-Mail"
-                v-model="emailValue"
-                :class="{
-                  input__invalid:
-                    emailValue !== '' && !emailValue.includes('@'),
-                }"
-              />
-              <span>Muss das @-Zeichen enthalten.</span>
-            </li>
-            <li class="question-list__item personal-item">
-              <label for="phone">Telefon</label>
-              <input
-                type="tel"
-                class="capp-input__default"
-                name="phone"
-                id="phone"
-                placeholder="Telefon"
-                v-model="phoneValue"
-                :class="{ input__invalid: /[a-zA-Z]/.test(phoneValue) }"
-              />
-              <span>Darf keine Buchstaben enthalten.</span>
-            </li>
-            <li class="question-list__item personal-item">
-              <label for="address">Straße, Haus-Nr.</label>
-              <input
-                type="text"
-                class="capp-input__default"
-                name="address"
-                id="address"
-                placeholder="Straße, Haus-Nr."
-                v-model="addressValue"
-                :class="{ input__invalid: addressValue.length === 1 }"
-              />
-              <span>Muss mindestens 2 Zeichen enthalten.</span>
-            </li>
-            <li class="question-list__item personal-item">
-              <label for="zipcode">PLZ</label>
-              <input
-                type="text"
-                class="capp-input__default"
-                name="zipcode"
-                id="zipcode"
-                placeholder="PLZ"
-                v-model="zipcodeValue"
-                :class="{
-                  input__invalid:
-                    zipcodeValue.length > 0 && zipcodeValue.length < 4,
-                }"
-              />
-              <span>Muss mindestens 4 Zeichen enthalten.</span>
-            </li>
-            <li class="question-list__item personal-item">
-              <label for="city">Wohnort</label>
-              <input
-                type="text"
-                class="capp-input__default"
-                name="city"
-                id="city"
-                placeholder="Ort"
-                v-model="cityValue"
-                :class="{
-                  input__invalid:
-                    cityValue.length === 1 ||
-                    /[0-9!?§$%&(){}€@#]/.test(cityValue),
-                }"
-              />
-              <span
-                >Muss mindestens 2 Zeichen, darf keine Ziffern oder
-                Sonderzeichen enthalten.</span
-              >
-            </li>
+            <!-- Username -->
+            <InputText
+              :inputId="'username'"
+              :inputType="'text'"
+              :inputPlaceholder="'Username'"
+              v-model:inputData="usernameValue"
+              >Nickname</InputText
+            >
+            <!-- Password -->
+            <input-text
+              :inputId="password"
+              :inputType="'password'"
+              :inputPlaceholder="'e.g. Pass-XY_word-2023'"
+              v-model:inputData="passwordValue"
+              >Password</input-text
+            >
+            <!-- Vorname -->
+            <input-text
+              :inputId="'firstname'"
+              :inputType="'text'"
+              :inputPlaceholder="'Vorname'"
+              v-model:inputData="firstnameValue"
+              >Vorname</input-text
+            >
+            <!-- Nachname -->
+            <input-text
+              :inputId="'lastname'"
+              :inputType="'text'"
+              :inputPlaceholder="'Nachname'"
+              v-model:inputData="lastnameValue"
+              >Nachname</input-text
+            >
+            <!-- E-Mail -->
+            <input-text
+              :inputId="'email'"
+              :inputType="'email'"
+              :inputPlaceholder="'meinKuerzel@provider.com'"
+              v-model:inputData="emailValue"
+              >E-Mail</input-text
+            >
+            <!-- Telefon -->
+            <input-text
+              :inputId="'phone'"
+              :inputType="'tel'"
+              :inputPlaceholder="'e.g. +49 231 33005318'"
+              v-model:inputData="phoneValue"
+              >Telefon</input-text
+            >
+            <!-- Adresse - Straße, Hausnummer -->
+            <input-text
+              :inputId="'address'"
+              :inputType="'text'"
+              :inputPlaceholder="'Straße, Hausnummer'"
+              v-model:inputData="addressValue"
+              >Straße, Haus-Nr.</input-text
+            >
+            <!-- PLZ / zipcode -->
+            <input-text
+              :inputId="'zipcode'"
+              :inputType="'text'"
+              :inputPlaceholder="'PLZ'"
+              v-model:inputData="zipcodeValue"
+              >PLZ</input-text
+            >
+            <!-- Wohnort / Stadt / City -->
+            <input-text
+              :inputId="'city'"
+              :inputType="'text'"
+              :inputPlaceholder="'Ort'"
+              v-model:inputData="cityValue"
+              >Wohnort</input-text
+            >
           </ul>
         </section>
       </article>
@@ -354,7 +271,7 @@
               />
               <label :for="`feature-${feature.id}`">{{ feature.name }}</label>
             </li>
-            <!-- Sonstiges -->
+            <!-- Sonstiges 
             <li class="question-list__item">
               <p>&nbsp;</p>
               <label for="misc">Sonstiges</label>
@@ -367,6 +284,14 @@
                 placeholder="Sonstiges"
               />
             </li>
+            -->
+            <input-text
+              :inputId="'misc'"
+              :inputType="'text'"
+              :inputPlaceholder="'Sonstiges'"
+              v-model:inputData="miscellaneous"
+              >Sonstiges</input-text
+            >
           </ul>
           <p hidden>{{ chosenFeatures }}</p>
         </section>
@@ -408,17 +333,13 @@
               >
             </li>
             <!-- Eigene Angaben -->
-            <li class="question-list__item">
-              <label for="own-trunk-size">Eigene Angaben</label>
-              <input
-                type="text"
-                class="capp-input__default"
-                name="own-trunk-size"
-                id="own-trunk-size"
-                v-model="ownTrunkSize"
-                placeholder="Eigene Angaben"
-              />
-            </li>
+            <input-text
+              :inputId="'own-trunk-size'"
+              :inputType="'text'"
+              :inputPlaceholder="'Eigene Angaben'"
+              v-model:inputData="ownTrunkSize"
+              >Eigene Angaben</input-text
+            >
           </ul>
         </section>
       </article>
@@ -480,8 +401,9 @@
 <script>
 import { supabase } from "../lib/supabaseClient";
 import CheckBox from "./input-elements/CheckBox.vue";
+import InputText from "./input-elements/InputText.vue";
 export default {
-  components: { CheckBox },
+  components: { CheckBox, InputText },
   data() {
     return {
       title: "CAPP Fragebogen",

--- a/src/components/UserQuestionMenue.vue
+++ b/src/components/UserQuestionMenue.vue
@@ -30,7 +30,7 @@
               v-model:inputData="usernameValue"
               >Nickname</InputText
             >
-            <!-- Password -->
+            <!-- Password 
             <input-text
               :inputId="password"
               :inputType="'password'"
@@ -38,6 +38,7 @@
               v-model:inputData="passwordValue"
               >Password</input-text
             >
+            -->
             <!-- Vorname -->
             <input-text
               :inputId="'firstname'"
@@ -392,7 +393,7 @@
               <select-drop-down
                 :selectId="'min-age'"
                 :givenData="minAges"
-                :defaultText="'--- Mindestalter'"
+                :defaultText="'--- keine Angabe'"
                 v-model:selectedData="chosenMinAge"
                 >Mindestalter</select-drop-down
               >
@@ -419,8 +420,8 @@ export default {
       h2textFeatures: "Ausstattung",
       h2textTrunkSize: "Kofferraum-Größen",
       h2textLimitations: "Einschränkungen für die Vermietung",
-      inputType: "password",
-      inputTypeText: "show Password",
+      //inputType: "password",
+      //inputTypeText: "show Password",
       usernameValue: "",
       passwordValue: "",
       firstnameValue: "",
@@ -613,24 +614,7 @@ export default {
           iconSource: "Raucher.svg",
         },
       ],
-      minAges: [
-        {
-          id: 0,
-          name: "keine Angabe",
-        },
-        {
-          id: 18,
-          name: "18 Jahre",
-        },
-        {
-          id: 21,
-          name: "21 Jahre",
-        },
-        {
-          id: 25,
-          name: "25 Jahre",
-        },
-      ],
+      minAges: [18, 21, 25],
     };
   },
   mounted() {

--- a/src/components/UserQuestionMenue.vue
+++ b/src/components/UserQuestionMenue.vue
@@ -368,6 +368,7 @@
                   {{ limitation.name }}</label
                 >
               </li>
+              <!-- 
               <li class="question-list__item capp-input__wrapper">
                 <label for="min-age" class="capp-label__default"
                   >Mindestalter</label
@@ -387,6 +388,14 @@
                   </option>
                 </select>
               </li>
+              -->
+              <select-drop-down
+                :selectId="'min-age'"
+                :givenData="minAges"
+                :defaultText="'--- Mindestalter'"
+                v-model:selectedData="chosenMinAge"
+                >Mindestalter</select-drop-down
+              >
             </ul>
             <p hidden>{{ chosenLimitations }}</p>
           </div>
@@ -399,8 +408,9 @@
 import { supabase } from "../lib/supabaseClient";
 import CheckBox from "./input-elements/CheckBox.vue";
 import InputText from "./input-elements/InputText.vue";
+import SelectDropDown from "./input-elements/SelectDropDown.vue";
 export default {
-  components: { CheckBox, InputText },
+  components: { CheckBox, InputText, SelectDropDown },
   data() {
     return {
       title: "CAPP Fragebogen",

--- a/src/components/input-elements/InputText.vue
+++ b/src/components/input-elements/InputText.vue
@@ -177,7 +177,7 @@ export default {
         case "datetime-local":
           return "Wähle einfach das passende Datum und die Zeit aus.";
         case "tel":
-          return "Deine Telefon-Nummer darf keine Buchstaben enthalten.";
+          return "Deine Telefon-Nummer darf keine Buchstaben oder Sonderzeichen wie ?,!,&,%,$,§,#,@ enthalten. Zulässige Sonderzeichen sind +, -, /, () und Leerzeichen.";
         case "number":
           return "Gib hier eine Zahl ein - oder zähle den Wert mit dem up-Pfeil hoch bzw. mit dem down-Pfeil herunter.";
         default:
@@ -193,7 +193,7 @@ export default {
         case "password":
           return "Leider wurden die Passwort-Kriterien nicht erfüllt";
         case "tel":
-          return "Deine Telefon-Nummer enthält Buchstaben.";
+          return "Deine Telefon-Nummer enthält Buchstaben oder unzulässige Sonderzeichen.";
         default:
           return "Da ist wohl was schief gelaufen?! Hierfür haben wir gerade keinen Hilfetext parat. Sollte das Problem noch einmal auftreten, kontaktiere uns unter 'capp.carsharing@gmail.com'.";
       }
@@ -233,7 +233,7 @@ export default {
       }
     },
     validatePhoneNumber(value) {
-      const validationRequirments = new RegExp(/^(?=.*[0-9()-+])/);
+      const validationRequirments = new RegExp(/^[0-9()+/ \b \-]*$/);
       if (validationRequirments.test(value) || value === "") {
         this.isValid = true;
         this.isInValid = false;

--- a/src/components/input-elements/InputText.vue
+++ b/src/components/input-elements/InputText.vue
@@ -136,9 +136,14 @@ export default {
       validator(value) {
         // Only input Element type specific names are allowed
         // List can be extented if needed
-        return ["text", "email", "password", "datetime-local", "tel"].includes(
-          value
-        );
+        return [
+          "text",
+          "email",
+          "password",
+          "datetime-local",
+          "tel",
+          "number",
+        ].includes(value);
       },
     },
     inputPlaceholder: {
@@ -173,6 +178,8 @@ export default {
           return "Wähle einfach das passende Datum und die Zeit aus.";
         case "tel":
           return "Deine Telefon-Nummer darf keine Buchstaben enthalten.";
+        case "number":
+          return "Gib hier eine Zahl ein - oder zähle den Wert mit dem up-Pfeil hoch bzw. mit dem down-Pfeil herunter.";
         default:
           return "Da ist wohl was schief gelaufen?! Hierfür haben wir gerade keinen Hilfetext parat. Sollte das Problem noch einmal auftreten, kontaktiere uns unter 'capp.carsharing@gmail.com'.";
       }

--- a/src/components/input-elements/InputText.vue
+++ b/src/components/input-elements/InputText.vue
@@ -136,7 +136,9 @@ export default {
       validator(value) {
         // Only input Element type specific names are allowed
         // List can be extented if needed
-        return ["text", "email", "password", "datetime-local"].includes(value);
+        return ["text", "email", "password", "datetime-local", "tel"].includes(
+          value
+        );
       },
     },
     inputPlaceholder: {
@@ -169,6 +171,8 @@ export default {
           return "Ein sicheres Passwort hat mindestens 12 Zeichen. Benutze hierbei bitte eine Mischung aus Groß-, Kleinschreibung, Sonderzeichen und Zahlen.";
         case "datetime-local":
           return "Wähle einfach das passende Datum und die Zeit aus.";
+        case "tel":
+          return "Deine Telefon-Nummer darf keine Buchstaben enthalten.";
         default:
           return "Da ist wohl was schief gelaufen?! Hierfür haben wir gerade keinen Hilfetext parat. Sollte das Problem noch einmal auftreten, kontaktiere uns unter 'capp.carsharing@gmail.com'.";
       }
@@ -181,6 +185,8 @@ export default {
           return "Die Mail-Adresse ist nicht korrekt.";
         case "password":
           return "Leider wurden die Passwort-Kriterien nicht erfüllt";
+        case "tel":
+          return "Deine Telefon-Nummer enthält Buchstaben.";
         default:
           return "Da ist wohl was schief gelaufen?! Hierfür haben wir gerade keinen Hilfetext parat. Sollte das Problem noch einmal auftreten, kontaktiere uns unter 'capp.carsharing@gmail.com'.";
       }
@@ -219,6 +225,16 @@ export default {
         this.isInValid = true;
       }
     },
+    validatePhoneNumber(value) {
+      const validationRequirments = new RegExp(/^(?=.*[0-9()-+])/);
+      if (validationRequirments.test(value) || value === "") {
+        this.isValid = true;
+        this.isInValid = false;
+      } else {
+        this.isValid = false;
+        this.isInValid = true;
+      }
+    },
   },
   watch: {
     /* Watchers for Validation */
@@ -227,6 +243,8 @@ export default {
         this.validateEmail(value);
       } else if (this.inputType === "password") {
         this.validatePassword(value);
+      } else if (this.inputType === "tel") {
+        this.validatePhoneNumber(value);
       }
     },
   },

--- a/src/components/input-elements/SelectDropDown.vue
+++ b/src/components/input-elements/SelectDropDown.vue
@@ -70,11 +70,26 @@
         <option disabled value="">{{ defaultText }}</option>
         <option v-for="name in givenData" :value="name.id" :key="name.id">
           <p v-if="multiColumn">
+            <span v-if="Object.keys(name)[1] === 'car_type_name'">{{
+              Object.values(name)[4]["brand_name"]
+            }}</span>
             {{ Object.values(name)[1] }}
+            <span v-if="Object.keys(name)[1] === 'car_type_name'"
+              >( {{ Object.values(name)[2] }} )</span
+            >
+            <span v-if="Object.keys(name)[1] === 'username'">
+              <span
+                v-if="
+                  Object.values(name)[3] !== null &&
+                  Object.values(name)[4] !== null
+                "
+              >
+                -
+              </span>
+              {{ Object.values(name)[3] }} {{ Object.values(name)[4] }}
+            </span>
           </p>
-          <p v-else>
-            {{ name }}
-          </p>
+          <p v-else>{{ name }}</p>
         </option>
       </select>
       {{ multiColumn }}
@@ -198,6 +213,7 @@ export default {
 .capp-input__default:focus {
   outline-color: var(--primary-light);
 }
+
 .capp-input__help-wrapper {
   position: relative;
 }

--- a/src/views/AddNewCarView.vue
+++ b/src/views/AddNewCarView.vue
@@ -25,13 +25,13 @@ export default {
       insuranceValue: "",
       insuranceNumberValue: "",
       fuelTypeValue: "",
-      fuelConsumeValue: 0,
-      kwValue: 0,
-      maxSpeedValue: 0,
-      yearOfConstruction: 0,
-      mileageValue: 0,
-      trunkVolume: 0,
-      seatCount: 0,
+      fuelConsumeValue: "0",
+      kwValue: "0",
+      maxSpeedValue: "0",
+      yearOfConstruction: "0",
+      mileageValue: "0",
+      trunkVolume: "0",
+      seatCount: "0",
       gearValue: "",
     };
   },
@@ -218,133 +218,49 @@ export default {
         -->
         <input-text
           :inputId="'fuel-consume'"
-          :inputType="'number'"
+          :inputType="'text'"
           v-model:inputData="fuelConsumeValue"
-          >Kraftstoffverbrauch / km</input-text
+          >Kraftstoffverbrauch in Liter/100 km</input-text
         >
       </div>
       <div class="form-row">
-        <!-- kw / PS 
-        <div class="capp-input__wrapper">
-          <label for="kw" class="capp-label__default">KiloWatt</label>
-          <input
-            type="number"
-            step="1"
-            name="kw"
-            id="kw"
-            class="capp-input__default"
-            v-model="kwValue"
-          />
-        </div>
-        -->
         <input-text
           :inputId="'kw'"
-          :inputType="'number'"
+          :inputType="'text'"
           v-model:inputData="kwValue"
           >PS</input-text
         >
-        <!-- max_speed 
-        <div class="capp-input__wrapper">
-          <label for="max-speed" class="capp-label__default"
-            >Höchst-Tempo</label
-          >
-          <input
-            type="number"
-            step="1"
-            name="max-speed"
-            id="max-speed"
-            class="capp-input__default"
-            v-model="maxSpeedValue"
-          />
-        </div>
-        -->
         <input-text
           :inputId="'max-speed'"
-          :inputType="'number'"
+          :inputType="'text'"
           v-model:inputData="maxSpeedValue"
           >Höchst-Tempo</input-text
         >
       </div>
       <div class="form-row">
-        <!-- year_of_construction 
-        <div class="capp-input__wrapper">
-          <label for="year" class="capp-label__default">Baujahr</label>
-          <input
-            type="number"
-            step="1"
-            name="year"
-            id="year"
-            class="capp-input__default"
-            v-model="yearOfConstruction"
-          />
-        </div>
-        -->
         <input-text
           :inputId="'year'"
-          :inputType="'number'"
+          :inputType="'text'"
           v-model:inputData="yearOfConstruction"
           >Baujahr</input-text
         >
-        <!-- mileage 
-        <div class="capp-input__wrapper">
-          <label for="mileage" class="capp-label__default">gefahrene km</label>
-          <input
-            type="number"
-            step="1"
-            name="mileage"
-            id="mileage"
-            class="capp-input__default"
-            v-model="mileageValue"
-          />
-        </div>
-        -->
         <input-text
           :inputId="'mileage'"
-          :inputType="'number'"
+          :inputType="'text'"
           v-model:inputData="mileageValue"
           >Ungefährer Kilometerstand</input-text
         >
       </div>
       <div class="form-row">
-        <!-- trunk_volume_in_liters 
-        <div class="capp-input__wrapper">
-          <label for="trunk-volume" class="capp-label__default"
-            >Kofferraum-Volumen</label
-          >
-          <input
-            type="number"
-            step="1"
-            name="trunk-volume"
-            id="trunk-volume"
-            class="capp-input__default"
-            v-model="trunkVolume"
-          />
-        </div>
-        -->
         <input-text
           :inputId="'trunk-volume'"
-          :inputType="'number'"
+          :inputType="'text'"
           v-model:inputData="trunkVolume"
           >Kofferraum-Volumen</input-text
         >
-        <!-- count of seats 
-        <div class="capp-input__wrapper">
-          <label for="seat-count" class="capp-label__default"
-            >Anzahl Sitze</label
-          >
-          <input
-            type="number"
-            step="1"
-            name="seat-count"
-            id="seat-count"
-            class="capp-input__default"
-            v-model="seatCount"
-          />
-        </div>
-        -->
         <input-text
           :inputId="'seat-count'"
-          :inputType="'number'"
+          :inputType="'text'"
           v-model:inputData="seatCount"
           >Anzahl freie Sitze</input-text
         >

--- a/src/views/AddNewCarView.vue
+++ b/src/views/AddNewCarView.vue
@@ -1,12 +1,14 @@
 <script>
 import { supabase } from "@/lib/supabaseClient";
 import InputText from "../components/input-elements/InputText.vue";
+import SelectDropDown from "../components/input-elements/SelectDropDown.vue";
 export default {
   data() {
     return {
       title: "Neues Auto erfassen",
       carTypes: null,
       users: null,
+      insurances: ["Vollkasko", "Teilkasko"],
       fuelTypes: [
         "Autogas",
         "Benzin",
@@ -15,6 +17,7 @@ export default {
         "Hybrid",
         "Wasserstoff",
       ],
+      gears: ["Automatik", "Schaltung"],
       carTypeValue: "",
       userValue: "",
       licensePlateValue: "",
@@ -32,7 +35,7 @@ export default {
       gearValue: "",
     };
   },
-  components: { InputText },
+  components: { InputText, SelectDropDown },
   mounted() {
     this.getCarTypes();
     this.getUsers();
@@ -63,7 +66,7 @@ export default {
     <h1>{{ title }}</h1>
     <form>
       <div class="form-row">
-        <!-- type_id -->
+        <!-- type_id 
         <div class="capp-input__wrapper">
           <label for="car-model" class="capp-label__default"
             >Auto-Marke/Modell</label
@@ -86,7 +89,15 @@ export default {
             </option>
           </select>
         </div>
-        <!-- user_id -->
+        -->
+        <select-drop-down
+          :selectId="'car-model'"
+          :givenData="carTypes"
+          :defaultText="'--- Auto-Marke/Modell'"
+          v-model:selectedData="carTypeValue"
+          >Auto-Marke/Modell</select-drop-down
+        >
+        <!-- user_id 
         <div class="capp-input__wrapper">
           <label for="user" class="capp-label__default">User</label>
           <select
@@ -101,6 +112,14 @@ export default {
             </option>
           </select>
         </div>
+        -->
+        <select-drop-down
+          :selectId="'user'"
+          :givenData="users"
+          :defaultText="'--- Anbieter'"
+          v-model:selectedData="userValue"
+          >User</select-drop-down
+        >
       </div>
       <div class="form-row">
         <!-- car_license_plate -->
@@ -121,7 +140,7 @@ export default {
         >
       </div>
       <div class="form-row">
-        <!-- insurance_type -->
+        <!-- insurance_type 
         <div class="capp-input__wrapper">
           <label for="insurance-type" class="capp-label__default"
             >Versicherung</label
@@ -137,6 +156,14 @@ export default {
             <option value="Teilkasko">Teilkasko</option>
           </select>
         </div>
+        -->
+        <select-drop-down
+          :selectId="'insurance-type'"
+          :givenData="insurances"
+          :defaultText="'--- Versicherungs-Art'"
+          v-model:selectedData="insuranceValue"
+          >Versicherung</select-drop-down
+        >
         <!-- insurance_no -->
         <input-text
           :inputId="'unsurance-number'"
@@ -147,7 +174,7 @@ export default {
         >
       </div>
       <div class="form-row">
-        <!-- fuel_type -->
+        <!-- fuel_type 
         <div class="capp-input__wrapper">
           <label for="fuel-type" class="capp-label__default">Kraftstoff</label>
           <select
@@ -166,7 +193,15 @@ export default {
             </option>
           </select>
         </div>
-        <!-- fuel_consume_per_km -->
+        -->
+        <select-drop-down
+          :selectId="'fuel-type'"
+          :givenData="fuelTypes"
+          :defaultText="'--- Kraftstoff'"
+          v-model:selectedData="fuelTypeValue"
+          >Kraftstoff</select-drop-down
+        >
+        <!-- fuel_consume_per_km 
         <div class="capp-input__wrapper">
           <label for="fuel-consume" class="capp-label__default"
             >Kraftstoffverbrauch / km</label
@@ -180,6 +215,13 @@ export default {
             v-model="fuelConsumeValue"
           />
         </div>
+        -->
+        <input-text
+          :inputId="'fuel-consume'"
+          :inputType="'number'"
+          v-model:inputData="fuelConsumeValue"
+          >Kraftstoffverbrauch / km</input-text
+        >
       </div>
       <div class="form-row">
         <!-- kw / PS 
@@ -260,7 +302,7 @@ export default {
           :inputId="'mileage'"
           :inputType="'number'"
           v-model:inputData="mileageValue"
-          >gefahrene Kilometer</input-text
+          >Ungefährer Kilometerstand</input-text
         >
       </div>
       <div class="form-row">
@@ -308,7 +350,7 @@ export default {
         >
       </div>
       <div class="form-row">
-        <!-- gear -->
+        <!-- gear 
         <div class="capp-input__wrapper">
           <label for="gear" class="capp-label__default">Getriebe</label>
           <select
@@ -322,6 +364,14 @@ export default {
             <option value="Schaltung">Schaltung</option>
           </select>
         </div>
+        -->
+        <select-drop-down
+          :selectId="'gear'"
+          :givenData="gears"
+          :defaultText="'--- Getriebe'"
+          v-model:selectedData="gearValue"
+          >Getriebe</select-drop-down
+        >
         <!-- submit -->
         <div class="capp-input__wrapper">
           <label for="add-car" class="capp-label__default">&nbsp;</label>

--- a/src/views/AddNewCarView.vue
+++ b/src/views/AddNewCarView.vue
@@ -104,31 +104,21 @@ export default {
       </div>
       <div class="form-row">
         <!-- car_license_plate -->
-        <div class="capp-input__wrapper">
-          <label for="license-plate" class="capp-label__default"
-            >Kennzeichen</label
-          >
-          <input
-            type="text"
-            name="license-plate"
-            id="license-plate"
-            class="capp-input__default"
-            placeholder="z.B. A-BC 123"
-            v-model="licensePlateValue"
-          />
-        </div>
+        <input-text
+          :inputId="'license-plate'"
+          :inputType="'text'"
+          :inputPlaceholder="'z.B. A-BC 123'"
+          v-model:inputData="licensePlateValue"
+          >Kennzeichen</input-text
+        >
         <!-- img_source -->
-        <div class="capp-input__wrapper">
-          <label for="img-source" class="capp-label__default">Bildquelle</label>
-          <input
-            type="text"
-            name="img-source"
-            id="img-source"
-            class="capp-input__default"
-            placeholder="z.B. https://bildpfad/bildname.png"
-            v-model="imgSourceValue"
-          />
-        </div>
+        <input-text
+          :inputId="'img-source'"
+          :inputType="'text'"
+          :inputPlaceholder="'z.B. https://bildpfad/bildname.png'"
+          v-model:inputData="imgSourceValue"
+          >Bildquelle</input-text
+        >
       </div>
       <div class="form-row">
         <!-- insurance_type -->
@@ -148,18 +138,13 @@ export default {
           </select>
         </div>
         <!-- insurance_no -->
-        <div class="capp-input__wrapper">
-          <label for="insurance-number" class="capp-label__default"
-            >Versicherungs-Nr.</label
-          >
-          <input
-            type="text"
-            name="insurance-number"
-            id="insurance-number"
-            class="capp-input__default"
-            v-model="insuranceNumberValue"
-          />
-        </div>
+        <input-text
+          :inputId="'unsurance-number'"
+          :inputType="'text'"
+          :inputPlaceholder="'z.B. VN-1201333'"
+          v-model:inputData="insuranceNumberValue"
+          >Versicherungs-Nr.</input-text
+        >
       </div>
       <div class="form-row">
         <!-- fuel_type -->
@@ -197,7 +182,7 @@ export default {
         </div>
       </div>
       <div class="form-row">
-        <!-- kw -->
+        <!-- kw / PS 
         <div class="capp-input__wrapper">
           <label for="kw" class="capp-label__default">KiloWatt</label>
           <input
@@ -209,7 +194,14 @@ export default {
             v-model="kwValue"
           />
         </div>
-        <!-- max_speed -->
+        -->
+        <input-text
+          :inputId="'kw'"
+          :inputType="'number'"
+          v-model:inputData="kwValue"
+          >PS</input-text
+        >
+        <!-- max_speed 
         <div class="capp-input__wrapper">
           <label for="max-speed" class="capp-label__default"
             >Höchst-Tempo</label
@@ -223,9 +215,16 @@ export default {
             v-model="maxSpeedValue"
           />
         </div>
+        -->
+        <input-text
+          :inputId="'max-speed'"
+          :inputType="'number'"
+          v-model:inputData="maxSpeedValue"
+          >Höchst-Tempo</input-text
+        >
       </div>
       <div class="form-row">
-        <!-- year_of_construction -->
+        <!-- year_of_construction 
         <div class="capp-input__wrapper">
           <label for="year" class="capp-label__default">Baujahr</label>
           <input
@@ -237,7 +236,14 @@ export default {
             v-model="yearOfConstruction"
           />
         </div>
-        <!-- mileage -->
+        -->
+        <input-text
+          :inputId="'year'"
+          :inputType="'number'"
+          v-model:inputData="yearOfConstruction"
+          >Baujahr</input-text
+        >
+        <!-- mileage 
         <div class="capp-input__wrapper">
           <label for="mileage" class="capp-label__default">gefahrene km</label>
           <input
@@ -249,9 +255,16 @@ export default {
             v-model="mileageValue"
           />
         </div>
+        -->
+        <input-text
+          :inputId="'mileage'"
+          :inputType="'number'"
+          v-model:inputData="mileageValue"
+          >gefahrene Kilometer</input-text
+        >
       </div>
       <div class="form-row">
-        <!-- trunk_volume_in_liters -->
+        <!-- trunk_volume_in_liters 
         <div class="capp-input__wrapper">
           <label for="trunk-volume" class="capp-label__default"
             >Kofferraum-Volumen</label
@@ -265,7 +278,14 @@ export default {
             v-model="trunkVolume"
           />
         </div>
-        <!-- mileage -->
+        -->
+        <input-text
+          :inputId="'trunk-volume'"
+          :inputType="'number'"
+          v-model:inputData="trunkVolume"
+          >Kofferraum-Volumen</input-text
+        >
+        <!-- count of seats 
         <div class="capp-input__wrapper">
           <label for="seat-count" class="capp-label__default"
             >Anzahl Sitze</label
@@ -279,6 +299,13 @@ export default {
             v-model="seatCount"
           />
         </div>
+        -->
+        <input-text
+          :inputId="'seat-count'"
+          :inputType="'number'"
+          v-model:inputData="seatCount"
+          >Anzahl freie Sitze</input-text
+        >
       </div>
       <div class="form-row">
         <!-- gear -->

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,19 +1,14 @@
 <template>
   <div>
     <h1>Test von Home View</h1>
-    <user-question-menue />
-    <p>&nbsp;</p>
-    <hr />
-    <p>&nbsp;</p>
     <filter-drop-down />
   </div>
 </template>
 
 <script>
 import FilterDropDown from "../components/FilterDropDown.vue";
-import UserQuestionMenue from "../components/UserQuestionMenue.vue";
 export default {
-  components: { FilterDropDown, UserQuestionMenue },
+  components: { FilterDropDown },
 };
 </script>
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,14 +1,19 @@
 <template>
   <div>
     <h1>Test von Home View</h1>
+    <user-question-menue />
+    <p>&nbsp;</p>
+    <hr />
+    <p>&nbsp;</p>
     <filter-drop-down />
   </div>
 </template>
 
 <script>
 import FilterDropDown from "../components/FilterDropDown.vue";
+import UserQuestionMenue from "../components/UserQuestionMenue.vue";
 export default {
-  components: { FilterDropDown },
+  components: { FilterDropDown, UserQuestionMenue },
 };
 </script>
 

--- a/src/views/KirstensView.vue
+++ b/src/views/KirstensView.vue
@@ -68,6 +68,8 @@ export default {
 </script>
 
 <template>
+  <UserQuestionMenue />
+
   <h2>{{ h2brands }}</h2>
 
   <form @submit.prevent="addNewBrand(this.newBrand)">
@@ -169,7 +171,6 @@ export default {
       </p>
     </li>
   </ul>
-  <UserQuestionMenue />
 </template>
 
 <style scoped>

--- a/src/views/KirstensView.vue
+++ b/src/views/KirstensView.vue
@@ -1,5 +1,6 @@
 <script>
 import { supabase } from "@/lib/supabaseClient";
+import UserQuestionMenue from "../components/UserQuestionMenue.vue";
 export default {
   data() {
     return {
@@ -14,7 +15,7 @@ export default {
       users: [],
     };
   },
-  components: {},
+  components: { UserQuestionMenue },
   mounted() {
     this.getBrands();
     this.getCarTypes();
@@ -168,6 +169,7 @@ export default {
       </p>
     </li>
   </ul>
+  <UserQuestionMenue />
 </template>
 
 <style scoped>


### PR DESCRIPTION
Habe die sowohl die Text-Felder durch InputText Komponente
als auch die Selects durch SelectDropDown Komponente 
ersetzt.
Habe die InputText Komponente um 2 weitere InputTypes erweitert
- [ ] 'tel'
- [ ] 'number'
und um eine weitere Validierungs-Methode für die Telefon-Nummer 
- [ ] ValidatePhoneNumber(value)

![Bildschirmfoto 2023-07-17 um 18 47 52](https://github.com/danielkull/capp/assets/122105147/bfcc5f36-7fa7-4262-9ccb-b4146209877e)

Bei der SelectDropDown Komponente habe ich das option element um einige conditional contents ergänzt, um die options in den Selects für Car Types bzw. Car Models und Users so zusammengesetzt anzeigen zu können.

![Bildschirmfoto 2023-07-17 um 17 08 54](https://github.com/danielkull/capp/assets/122105147/dcd61392-1af1-48d6-ba2b-72b932d94263)
![Bildschirmfoto 2023-07-17 um 17 02 10](https://github.com/danielkull/capp/assets/122105147/00b6b8d0-3a9d-424c-8b3e-e32e4fd81607)
![Bildschirmfoto 2023-07-17 um 17 01 48](https://github.com/danielkull/capp/assets/122105147/b5d9831c-6c35-4f7c-9b43-89077dcd303f)
