### PR TITLE
280 zusaetzliche logik beim buchungsanfragen

### DIFF
--- a/src/components/main-component/expand-menu-components/DeleteLogQuestion.vue
+++ b/src/components/main-component/expand-menu-components/DeleteLogQuestion.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="question-frame">
-    <p v-if="deleteLog === 'profil-delete'">
+    <p v-if="deleteLogProfil === 'profil-delete'">
       Willst Du dein Konto wirklich löschen ?
     </p>
 
@@ -10,7 +10,7 @@
     </span>
   </section>
 
-  <section class="question-frame" v-if="deletelog === 'profil-logout'">
+  <section class="question-frame" v-if="deleteLogProfil === 'profil-logout'">
     <p>Willst Dich wirklich abmelden ?</p>
     <span class="quest-answer">
       <button><p>Ja</p></button>
@@ -21,12 +21,13 @@
 
 <script>
 export default {
-  props: {
+  props: ["deleteLogProfil"],
+  /*   props: {
     deleteLog: {
       type: String,
       required: true,
     },
-  },
+  }, */
 };
 </script>
 

--- a/src/components/main-component/expand-menu-components/ImpressumdatSecurText.vue
+++ b/src/components/main-component/expand-menu-components/ImpressumdatSecurText.vue
@@ -225,7 +225,6 @@
         possimus assumenda quas amet natus neque eos cupiditate aut, voluptas
         sunt labore mollitia.
       </p>
-      <plorem></plorem>
     </section>
   </article>
 </template>

--- a/src/components/main-component/expand-site-cards/BookingCalendarExpandCard.vue
+++ b/src/components/main-component/expand-site-cards/BookingCalendarExpandCard.vue
@@ -70,7 +70,6 @@ export default {
   methods: {
     showSelectedDate(value) {
       this.newDate = value;
-      console.log(this.newDate);
     },
   },
 };

--- a/src/components/main-component/expand-site-cards/DeleteExpandCard.vue
+++ b/src/components/main-component/expand-site-cards/DeleteExpandCard.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="menue-expand__outer-wrapper" id="delete">
     <article class="question-card">
-      <DeleteLogCard :deleteLog="'profil-delete'" />
+      <DeleteLogCard deleteLogProfil="profil-delete" />
     </article>
   </section>
 </template>

--- a/src/components/main-component/expand-site-cards/LogoutEpandCard.vue
+++ b/src/components/main-component/expand-site-cards/LogoutEpandCard.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="menue-expand__outer-wrapper" id="logout-user">
     <article class="question-card">
-      <DeleteLogCard :deleteLog="'profil-logout'" />
+      <DeleteLogCard deleteLogProfil="profil-logout" />
     </article>
   </section>
 </template>

--- a/src/components/messenger/MessageBox.vue
+++ b/src/components/messenger/MessageBox.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- ========= Start small Message View ========= -->
   <article class="booking-message-section">
     <header class="booking-message__header">
       <section class="booking-message__header-profil-wrapper">
@@ -11,8 +12,15 @@
       </section>
     </header>
     <main>
-      <p class="booking-message__period">
+      <p v-if="routeData.status === 'accepted'" class="booking-message__period">
+        Klasse, deine Anfrage wurde angenommen. Bitte nehme nun Kontakt mit dem
+        Car Owner auf!
+      </p>
+      <p v-if="routeData.status === 'pending'" class="booking-message__period">
         {{ period }}
+      </p>
+      <p v-if="routeData.status === 'declined'" class="booking-message__period">
+        Leider hats nicht geklappt. Versuch es doch bei einem anderen Car Owner.
       </p>
     </main>
     <footer class="booking-message__footer">
@@ -43,6 +51,8 @@
       ></Button>
     </footer>
   </article>
+  <!-- ========= End small Message View ========= -->
+  <!-- ========= Start Extended Message View ========= -->
   <article v-if="showExtendedMsg" class="extended-booking-message-section">
     <header class="extended-booking-message__header">
       <div
@@ -92,21 +102,28 @@
       </h4>
       <p class="message-text">{{ routeData.booking_msg }}</p>
     </main>
-    <footer class="extended-booking-message__footer">
-      <Button
-        value="Akzeptieren"
-        id="extended-msg-btn__accept"
-        class="booking-messsage__button"
-        @click.prevent="changeRouteStatus('accepted')"
-      ></Button>
-      <Button
-        value="Ablehnen"
-        id="extended-msg-btn__decline"
-        class="booking-messsage__button decline-btn"
-        @click.prevent="changeRouteStatus('declined')"
-      ></Button>
+    <footer>
+      <section
+        v-if="msgFromMe"
+        class="extended-booking-message__footer"
+      ></section>
+      <section v-else class="extended-booking-message__footer">
+        <Button
+          value="Akzeptieren"
+          id="extended-msg-btn__accept"
+          class="booking-messsage__button"
+          @click.prevent="changeRouteStatus('accepted')"
+        ></Button>
+        <Button
+          value="Ablehnen"
+          id="extended-msg-btn__decline"
+          class="booking-messsage__button decline-btn"
+          @click.prevent="changeRouteStatus('declined')"
+        ></Button>
+      </section>
     </footer>
   </article>
+  <!-- ========= End Extended Message View ========= -->
 </template>
 
 <script>
@@ -191,8 +208,6 @@ export default {
         .update({ status: newStatus })
         .eq("id", this.routeData.id)
         .select("id, status");
-      console.log("Data: ", data);
-      console.log("Error: ", error);
       this.$emit("updateRouteStatus", data);
       this.showExtendedMsg = false;
     },

--- a/src/components/messenger/messenger-placeholder/MessageChatWindow.vue
+++ b/src/components/messenger/messenger-placeholder/MessageChatWindow.vue
@@ -21,7 +21,9 @@
         </div>
       </article>
       <article class="chat__time-stamp">
-        <day>Montag</day> <date>23.5.23</date>
+        <!--  -->
+        <!-- <day>Montag</day> <date>23.5.23</date> -->
+        <span>Montag</span> <span>23.5.23</span>
       </article>
       <article class="chat-text__own">
         <div class="text-user__own txt-user">
@@ -71,7 +73,8 @@
         </div>
       </article>
       <article class="chat__time-stamp">
-        <day>Dienstag</day> <date>24.5.23</date>
+        <!-- <day>Dienstag</day> <date>24.5.23</date> -->
+        <span>Dienstag</span> <span>24.5.23</span>
       </article>
 
       <article class="chat-text__other-user">

--- a/src/stores/useAuthenticationStore.js
+++ b/src/stores/useAuthenticationStore.js
@@ -45,7 +45,7 @@ export const useAuthenticationStore = defineStore("authentication", {
           this.activeUser = data;
         }
       } catch (error) {
-        console.log(error.message);
+        alert(error.message);
       }
     },
   },


### PR DESCRIPTION
Resolves #280 

<details><summary>Details</summary>
<p>

- [x] Beim Status Bestätigt / Abgelehnt einen kurzen Text statt Datum anzeigen
- [x] Akzeptieren und Ablehnen ist nur für den Empfänger Möglich. Absender kriegt in Zukunft andere Möglichkeiten wie (z.B. editieren oder zurückziehen)
- [x]  Zusätzlich: Vue Warnings gefixed im MainView und ein paar console.logs entfernt

</p>
</details> 