### PR TITLE
refactor: fixes navbar menue, now only one view is opend

### DIFF
--- a/src/components/main-component/NavBar.vue
+++ b/src/components/main-component/NavBar.vue
@@ -5,6 +5,8 @@
       name="nav-menue"
       id="user-icon"
       class="nav-bar__btn-icons"
+      ref="navUserMenue"
+      @click="handleNavbarActivation"
     />
     <label class="nav-bar__icon-frame" for="user-icon">
       <svg
@@ -26,7 +28,11 @@
       name="nav-menue"
       id="calendar-icon"
       class="nav-bar__btn-icons"
-      @click="startBookingCalendar"
+      ref="navCalendarMenue"
+      @click="
+        startBookingCalendar();
+        handleNavbarActivation($event);
+      "
     />
     <label class="nav-bar__icon-frame" for="calendar-icon">
       <svg
@@ -51,7 +57,8 @@
       name="nav-menue"
       id="message-icon"
       class="nav-bar__btn-icons"
-      @toggle="testToggle"
+      ref="navMessageMenue"
+      @click="handleNavbarActivation"
     /><label class="nav-bar__icon-frame" for="message-icon"
       ><svg
         xmlns="http://www.w3.org/2000/svg"
@@ -75,7 +82,8 @@
       name="nav-menue"
       id="menue-icon"
       class="nav-bar__btn-icons"
-      @click="testItem"
+      ref="navSettingsMenue"
+      @click="handleNavbarActivation"
     /><label class="nav-bar__icon-frame" for="menue-icon">
       <div class="menue-wrapper">
         <span class="menue-strip menue-strip1"></span
@@ -181,6 +189,31 @@ export default {
     startBookingCalendar() {
       this.activeUser = this.authenticationStore.activeUser;
       this.bookingViewToggle = !this.bookingViewToggle;
+    },
+    handleNavbarActivation(event) {
+      // The selected checkbox of the navbar
+      let currentNavMenue = event.target;
+      // save the reference to all navbar checkboxes
+      const navUserMenue = this.$refs.navUserMenue;
+      const navCalendarMenue = this.$refs.navCalendarMenue;
+      const navMessageMenue = this.$refs.navMessageMenue;
+      const navSettingsMenue = this.$refs.navSettingsMenue;
+
+      // Check that not the current checkbox is set to 'false'
+      if (navUserMenue.id !== currentNavMenue.id) {
+        navUserMenue.checked = false;
+      }
+      if (navCalendarMenue.id !== currentNavMenue.id) {
+        navCalendarMenue.checked = false;
+      }
+      if (navMessageMenue.id !== currentNavMenue.id) {
+        navMessageMenue.checked = false;
+      }
+      if (navSettingsMenue.id !== currentNavMenue.id) {
+        navSettingsMenue.checked = false;
+      }
+      // Since toggle is part of the native html checkbox, we don't need to handle the current checkbox further.
+      // this.bookingViewToggl = navCalendarMenue.checked;
     },
   },
 };

--- a/src/components/main-component/expand-menu-components/TeamSingle.vue
+++ b/src/components/main-component/expand-menu-components/TeamSingle.vue
@@ -18,7 +18,7 @@
           v-if="teamMember === 'Daniel'"
           class="name"
           href="https://github.com/danielkull"
-          >Daniel Kuhl</a
+          >Daniel Kull</a
         >
         <a
           v-if="teamMember === 'Kerstin'"


### PR DESCRIPTION
Solves #290 

<details><summary>Details</summary>
<p>

Beim aktiveren von mehreren navbar buttons, schalten sich die vorherigen nicht selbst wieder zurück.
Erwartetes Verhalten: Es ist nur ein Navbutton aktive und wird deaktivert samt View wenn man auf einen anderen Button klickt.

- [x] Gewünschte Navbar Funktionalität umgesetzt.

![image](https://github.com/danielkull/capp/assets/119632155/086bc9f3-452b-4d4a-bac7-87e321a665b2)


</p>
</details> 


![image](https://github.com/danielkull/capp/assets/119632155/e989f646-13f4-4990-ac92-4b65127726ab)
