### PR TITLE
Profile settings data editable

### DIFF
--- a/src/components/main-component/expand-menu-components/CarDataTable.vue
+++ b/src/components/main-component/expand-menu-components/CarDataTable.vue
@@ -1,13 +1,23 @@
 <template>
   <section class="site__wrapper">
-    <article class="user-table__wrapper">
+    <article
+      class="user-table__wrapper"
+      :class="{ 'change-btn__active': !notEditableInsuranceInfo }"
+    >
       <table width="100%">
         <thead>
           <tr>
             <th width="40%">Versicherung</th>
             <th width="60%">
-              <label for="change-btn"
-                ><input type="button" value="" id="change-btn" /><svg
+              <label for="change-btn__insurance-info"
+                ><input
+                  type="button"
+                  value=""
+                  class="change-btn"
+                  :class="{ 'change-btn__active': !notEditableInsuranceInfo }"
+                  id="change-btn__insurance-info"
+                  @click.prevent="editInsuranceInfo"
+                /><svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="100%"
                   height="100%"
@@ -21,44 +31,85 @@
                   <path
                     fill-rule="evenodd"
                     d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5v11z"
-                  /></svg
-              ></label>
+                  />
+                </svg>
+              </label>
             </th>
           </tr>
         </thead>
         <tbody>
           <tr>
+            <!-- At the moment ther exist no driving license number in the database -->
             <td>Führerschein- <br />nummer</td>
-            <td>1236666</td>
+            <td>
+              <input
+                v-model="drivingLicenseNo"
+                class="car-settings__form-text-input"
+                type="text"
+                :disabled="true"
+              />
+            </td>
           </tr>
           <tr>
             <td>Versicherung</td>
-            <td>Vollkasko</td>
+            <td>
+              <select
+                class="car-settings__form-text-input car-settings__drop-down-menu"
+                name="insuranceDropDown"
+                id="insuranceDropDown"
+                :value="insuranceTyp"
+                v-model="insuranceTyp"
+                :disabled="notEditableInsuranceInfo"
+              >
+                <option disabled value="">{{ insuranceTyp }}</option>
+                <option
+                  v-for="insurance in insuranceData"
+                  :value="insurance"
+                  :key="insurance"
+                >
+                  {{ insurance }}
+                </option>
+              </select>
+            </td>
           </tr>
           <tr>
             <td>
               Versicherungs- <br />
               nummer
             </td>
-            <td>HC12344</td>
-          </tr>
-          <tr>
-            <td>Kennzeichen</td>
-            <td>CC-DD234</td>
+            <td>
+              <input
+                v-model="insuranceNumber"
+                class="car-settings__form-text-input"
+                type="text"
+                :disabled="notEditableInsuranceInfo"
+              />
+            </td>
           </tr>
         </tbody>
       </table>
     </article>
 
     <!-------------------------------------------------------------->
-    <article class="user-table__wrapper">
+    <article
+      class="user-table__wrapper"
+      :class="{ 'change-btn__active': !notEditableCarInfo }"
+    >
       <table width="100%">
         <thead>
           <tr>
             <th width="40%">Fahrzeug Info</th>
             <th width="60%">
-              <label for="change-btn"
-                ><input type="button" value="" id="change-btn" /><svg
+              <label for="change-btn__car-info"
+                ><input
+                  type="button"
+                  value=""
+                  class="change-btn"
+                  :class="{ 'change-btn__active': !notEditableCarInfo }"
+                  id="change-btn__car-info"
+                  @click.prevent="editCarInfo"
+                />
+                <svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="100%"
                   height="100%"
@@ -72,44 +123,92 @@
                   <path
                     fill-rule="evenodd"
                     d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5v11z"
-                  /></svg
-              ></label>
+                  />
+                </svg>
+              </label>
             </th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td>Automarke</td>
-            <td>Renault</td>
+            <td>
+              <input
+                v-model="carBrand"
+                class="car-settings__form-text-input"
+                type="text"
+                :disabled="true"
+              />
+            </td>
           </tr>
           <tr>
             <td>Modell</td>
-            <td>Twingo</td>
+            <td>
+              <input
+                v-model="carModel"
+                class="car-settings__form-text-input"
+                type="text"
+                :disabled="true"
+              />
+            </td>
           </tr>
           <tr>
             <td>Kennzeichen</td>
-            <td>CC-DD234</td>
+            <td>
+              <input
+                v-model="licensePlate"
+                class="car-settings__form-text-input"
+                type="text"
+                :disabled="notEditableCarInfo"
+              />
+            </td>
           </tr>
           <tr>
             <td>Baujahr</td>
-            <td>2011</td>
+            <td>
+              <input
+                v-model="manufactureYear"
+                class="car-settings__form-text-input"
+                type="number"
+                :disabled="notEditableCarInfo"
+              />
+            </td>
           </tr>
           <tr>
             <td>Ladevolumen</td>
-            <td>175 l</td>
+            <td>
+              <input
+                v-model="trunkSize"
+                class="car-settings__form-text-input"
+                type="number"
+                :disabled="notEditableCarInfo"
+              />
+            </td>
           </tr>
         </tbody>
       </table>
     </article>
     <!-------------------------------------------------------------->
-    <article class="user-table__wrapper">
+    <article
+      class="user-table__wrapper"
+      :class="{ 'change-btn__active': !notEditableCarPerformanceInfo }"
+    >
       <table width="100%">
         <thead>
           <tr>
             <th width="40%">Leistung</th>
             <th width="60%">
-              <label for="change-btn"
-                ><input type="button" value="" id="change-btn" /><svg
+              <label for="change-btn_car-performance-info"
+                ><input
+                  type="button"
+                  value=""
+                  class="change-btn"
+                  :class="{
+                    'change-btn__active': !notEditableCarPerformanceInfo,
+                  }"
+                  id="change-btn_car-performance-info"
+                  @click.prevent="editCarPerformanceInfo"
+                /><svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="100%"
                   height="100%"
@@ -123,27 +222,63 @@
                   <path
                     fill-rule="evenodd"
                     d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5v11z"
-                  /></svg
-              ></label>
+                  />
+                </svg>
+              </label>
             </th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td>Getriebe</td>
-            <td>Schaltung</td>
+            <td>
+              <select
+                class="car-settings__form-text-input car-settings__drop-down-menu"
+                name="gearBoxDropDown"
+                id="gearBoxDropDown"
+                :value="gearBox"
+                v-model="gearBox"
+                :disabled="notEditableCarPerformanceInfo"
+              >
+                <option disabled value="">{{ gearBox }}</option>
+                <option v-for="gear in gearData" :value="gear" :key="gear">
+                  {{ gear }}
+                </option>
+              </select>
+            </td>
           </tr>
           <tr>
             <td>Verbrauch / km</td>
-            <td>1.25 l</td>
+            <td>
+              <input
+                v-model="carConsumption"
+                class="car-settings__form-text-input"
+                type="number"
+                :disabled="notEditableCarPerformanceInfo"
+              />
+            </td>
           </tr>
           <tr>
             <td>PS</td>
-            <td>100</td>
+            <td>
+              <input
+                v-model="horsePower"
+                class="car-settings__form-text-input"
+                type="number"
+                :disabled="notEditableCarPerformanceInfo"
+              />
+            </td>
           </tr>
           <tr>
             <td>Höchst-<br />geschwind.</td>
-            <td>175 km/h</td>
+            <td>
+              <input
+                v-model="topSpeed"
+                class="car-settings__form-text-input"
+                type="number"
+                :disabled="notEditableCarPerformanceInfo"
+              />
+            </td>
           </tr>
         </tbody>
       </table>
@@ -152,7 +287,232 @@
 </template>
 
 <script>
-export default {};
+import { useGlobalStateStore } from "@/stores/useGlobalStateStore";
+import { useAuthenticationStore } from "@/stores/useAuthenticationStore.js";
+import { useCarStore } from "@/stores/useCarStore.js";
+
+export default {
+  data() {
+    return {
+      // Collection of Data to work with
+      activeUser: "",
+      userCar: null,
+      gearData: null,
+      insuranceData: null,
+      // to Catch and transfer Data to Database
+      drivingLicenseNo: null,
+      insuranceTyp: null,
+      insuranceNumber: null,
+      carBrand: null,
+      carModel: null,
+      licensePlate: null,
+      manufactureYear: null,
+      trunkSize: null,
+      gearBox: null,
+      carConsumption: null,
+      horsePower: null,
+      topSpeed: null,
+      // Different status checks for this component
+      notEditableInsuranceInfo: true,
+      notEditableCarInfo: true,
+      notEditableCarPerformanceInfo: true,
+      insuranceInfosChanged: false,
+      carInfosChanged: false,
+      carPerformanceInfosChanged: false,
+      notACarOwner: false,
+    };
+  },
+  setup() {
+    const globalStateStore = useGlobalStateStore();
+    const authenticationStore = useAuthenticationStore();
+    const carStore = useCarStore();
+    return { globalStateStore, authenticationStore, carStore };
+  },
+  beforeCreate() {
+    // Gets the current User for this component
+    this.$watch(
+      () => this.authenticationStore.activeUser,
+      (activeUser) => {
+        this.activeUser = activeUser[0];
+      }
+    );
+  },
+  methods: {
+    editInsuranceInfo() {
+      if (this.notACarOwner) {
+        return;
+      } else {
+        this.notEditableInsuranceInfo = !this.notEditableInsuranceInfo;
+        if (this.insuranceInfosChanged) {
+          // Data set for the update function
+          let dataToUpdate = {
+            activeUserCarID: this.userCar[0].id,
+            insurance_no: this.insuranceNumber,
+            insurance_type: this.insuranceTyp,
+          };
+          // The update function
+          this.carStore.updateCarInsuranceInfo(dataToUpdate);
+          // set dataChange back to default
+          this.insuranceInfosChanged = false;
+        }
+      }
+    },
+    editCarInfo() {
+      if (this.notACarOwner) {
+        return;
+      } else {
+        this.notEditableCarInfo = !this.notEditableCarInfo;
+        if (this.carInfosChanged) {
+          // Data set for the update function
+          let dataToUpdate = {
+            activeUserCarID: this.userCar[0].id,
+            licensePlate: this.licensePlate,
+            manufactureYear: this.manufactureYear,
+            trunkSize: this.trunkSize,
+          };
+          // The update function
+          this.carStore.updateCarInfo(dataToUpdate);
+          // set dataChange back to default
+          this.carInfosChanged = false;
+        }
+      }
+    },
+    editCarPerformanceInfo() {
+      if (this.notACarOwner) {
+        return;
+      } else {
+        this.notEditableCarPerformanceInfo =
+          !this.notEditableCarPerformanceInfo;
+        if (this.carPerformanceInfosChanged) {
+          // Data set for the update function
+          let dataToUpdate = {
+            activeUserCarID: this.userCar[0].id,
+            gearBox: this.gearBox,
+            carConsumption: this.carConsumption,
+            horsePower: this.horsePower,
+            topSpeed: this.topSpeed,
+          };
+          // The update function
+          this.carStore.updateCarPerformanceInfo(dataToUpdate);
+          // set dataChange back to default
+          this.carPerformanceInfosChanged = false;
+        }
+      }
+    },
+    // Gets user car with current User id and update the infos in this component
+    async getUserCarFromStore() {
+      await this.carStore.getUserCar(this.activeUser.id);
+      // Get further data for enum select input
+      await this.carStore.getGearData();
+      await this.carStore.getInsuranceData();
+      // await this.carStore.getUserCar(200);
+      this.userCar = await this.carStore.userCar;
+      this.gearData = await this.carStore.gearData;
+      this.insuranceData = await this.carStore.insuranceData;
+    },
+  },
+  watch: {
+    // Checks if current user is loaded, if yes get user car
+    activeUser(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.getUserCarFromStore();
+      }
+    },
+    // Checks if user car is loaded
+    userCar(newValue) {
+      // User has no car? Then put everything to not available (N/A)
+      if (newValue.length === 0) {
+        this.drivingLicenseNo = "N/A";
+        this.insuranceTyp = "N/A";
+        this.insuranceNumber = "N/A";
+        this.carBrand = "N/A";
+        this.carModel = "N/A";
+        this.licensePlate = "N/A";
+        this.manufactureYear = 0;
+        this.trunkSize = 0;
+        this.gearBox = "N/A";
+        this.carConsumption = 0;
+        this.horsePower = 0;
+        this.topSpeed = 0;
+        this.notACarOwner = true;
+      } else {
+        this.drivingLicenseNo = "N/A";
+        this.insuranceTyp = newValue[0].insurance_type;
+        this.insuranceNumber = newValue[0].insurance_no;
+        this.carBrand = "N/A";
+        this.carModel = "N/A";
+        this.licensePlate = newValue[0].car_license_plate;
+        this.manufactureYear = newValue[0].year_of_construction;
+        this.trunkSize = newValue[0].trunk_volume_in_liters;
+        this.gearBox = newValue[0].gear;
+        this.carConsumption = newValue[0].fuel_consume_per_km;
+        this.horsePower = newValue[0].kw;
+        this.topSpeed = newValue[0].max_speed;
+      }
+    },
+    // Watch if any data were changed by user
+    drivingLicenseNo(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.insuranceInfosChanged = true;
+      }
+    },
+    insuranceTyp(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.insuranceInfosChanged = true;
+      }
+    },
+    insuranceNumber(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.insuranceInfosChanged = true;
+      }
+    },
+    carBrand(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.carInfosChanged = true;
+      }
+    },
+    carModel(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.carInfosChanged = true;
+      }
+    },
+    licensePlate(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.carInfosChanged = true;
+      }
+    },
+    manufactureYear(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.carInfosChanged = true;
+      }
+    },
+    trunkSize(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.carInfosChanged = true;
+      }
+    },
+    gearBox(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.carPerformanceInfosChanged = true;
+      }
+    },
+    carConsumption(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.carPerformanceInfosChanged = true;
+      }
+    },
+    horsePower(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.carPerformanceInfosChanged = true;
+      }
+    },
+    topSpeed(newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.carPerformanceInfosChanged = true;
+      }
+    },
+  },
+};
 </script>
 
 <style scoped>
@@ -183,9 +543,7 @@ input[type="button"] {
   height: 0;
   top: -99999px;
 }
-#change-btn:active ~ svg {
-  fill: var(--check-checked);
-}
+
 /*===================================*/
 label {
   display: block;
@@ -199,6 +557,16 @@ label svg {
   height: var(--m-font);
   fill: var(--text-light);
 }
+/* Styling after edit button is pressed */
+.change-btn:active ~ svg {
+  fill: var(--check-checked);
+}
+.change-btn__active,
+.change-btn__active ~ svg {
+  fill: var(--secondary-color);
+  box-shadow: 0px 0px 15px var(--secondary-color);
+}
+/* end of edit button styling */
 table :is(td, input, p) {
   font-size: clamp(0.9rem, 3vw, 1.3rem);
 }
@@ -234,4 +602,37 @@ tr:nth-child(even) {
 }
 
 /*===============================================*/
+/* === Styling of Input Elements === */
+.car-settings__form-text-input,
+.car-settings__form-text-input:focus {
+  font-family: var(--def-font-style);
+  border: none;
+  color: var(--text-light);
+  font-weight: var(--f-weight-m);
+  text-align: right;
+  background: transparent;
+  outline-offset: var(--xs-pad);
+  outline-color: var(--shd-single-cards);
+}
+.car-settings__form-text-input:focus {
+  box-shadow: 0 0 20px 1px var(--shd-single-cards);
+  background: rgba(102, 100, 100, 0.08);
+  color: var(--text-mid);
+}
+
+/* .car-settings__drop-down-menu {
+  background-color: transparent;
+} */
+select {
+  color: var(--text-mid);
+  background: var(--sur-dark-shd);
+  border-radius: 0.05rem;
+}
+
+option {
+  color: var(--text-mid);
+  background: var(--sur-dark-shd);
+}
+
+/* === End of Styling of Input Elements === */
 </style>

--- a/src/components/main-component/expand-menu-components/DeleteLogQuestion.vue
+++ b/src/components/main-component/expand-menu-components/DeleteLogQuestion.vue
@@ -26,11 +26,22 @@
       <button @click.prevent="closePage"><p>Ja</p></button>
     </span>
   </section>
+  <!-- Window for changing User Setttings Data -->
+  <section
+    class="question-frame"
+    v-if="deleteLogProfil === 'user-settings-confirmation'"
+  >
+    <p>Möchtest du deine Änderungen speichern?</p>
+    <span class="quest-answer">
+      <button @click.prevent="closePage"><p>Ja</p></button>
+      <button @click.prevent="closePage"><p>Nein</p></button>
+    </span>
+  </section>
 </template>
 
 <script>
 import { useAuthenticationStore } from "@/stores/useAuthenticationStore";
-import { useGlobalStateStore } from "@/stores/useGlobalStateStore"; 
+import { useGlobalStateStore } from "@/stores/useGlobalStateStore";
 
 export default {
   props: ["deleteLogProfil"],
@@ -48,7 +59,7 @@ export default {
     closePage() {
       this.globalStateStore.translateCard = "-100% 0%";
       this.$router.go(-2);
-    }
+    },
   },
 };
 </script>

--- a/src/components/main-component/expand-menu-components/UserDatesTable.vue
+++ b/src/components/main-component/expand-menu-components/UserDatesTable.vue
@@ -1,13 +1,23 @@
 <template>
   <section class="site__wrapper">
-    <article class="user-table__wrapper">
+    <article
+      class="user-table__wrapper"
+      :class="{ 'change-btn__active': !notEditableBasicInfos }"
+    >
       <table width="100%">
         <thead>
           <tr>
             <th width="30%">Basis Info</th>
             <th width="70%">
-              <label for="change-btn"
-                ><input type="button" value="" id="change-btn" /><svg
+              <label for="change-btn__basis-info"
+                ><input
+                  type="button"
+                  value=""
+                  class="change-btn"
+                  :class="{ 'change-btn__active': !notEditableBasicInfos }"
+                  id="change-btn__basis-info"
+                  @click.prevent="editBasicInfo"
+                /><svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="100%"
                   height="100%"
@@ -30,15 +40,29 @@
         <tbody>
           <tr>
             <td>Anrede</td>
-            <td>Herr</td>
+            <td>Frau / Herr</td>
           </tr>
           <tr>
             <td>Nachname</td>
-            <td>Musteetzwe</td>
+            <td>
+              <input
+                v-model="firstname"
+                class="user-settings__form-text-input"
+                type="text"
+                :disabled="notEditableBasicInfos"
+              />
+            </td>
           </tr>
           <tr>
             <td>Vorname</td>
-            <td>Max</td>
+            <td>
+              <input
+                v-model="lastname"
+                class="user-settings__form-text-input"
+                type="text"
+                :disabled="notEditableBasicInfos"
+              />
+            </td>
           </tr>
         </tbody>
       </table>
@@ -51,14 +75,24 @@
 
     <!------------------------------------------------------------------------------------------------>
 
-    <article class="user-table__wrapper">
+    <article
+      class="user-table__wrapper"
+      :class="{ 'change-btn__active': !notEditableAddress }"
+    >
       <table width="100%">
         <thead>
           <tr>
             <th width="30%">Adresse</th>
             <th width="70%">
-              <label for="change-btn"
-                ><input type="button" value="" id="change-btn" /><svg
+              <label for="change-btn__address"
+                ><input
+                  type="button"
+                  value=""
+                  class="change-btn"
+                  :class="{ 'change-btn__active': !notEditableAddress }"
+                  id="change-btn__address"
+                  @click.prevent="editAdress"
+                /><svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="100%"
                   height="100%"
@@ -81,15 +115,36 @@
         <tbody>
           <tr>
             <td>Straße</td>
-            <td>Fantasystraße</td>
+            <td>
+              <input
+                v-model="address"
+                class="user-settings__form-text-input"
+                type="text"
+                :disabled="notEditableAddress"
+              />
+            </td>
           </tr>
           <tr>
             <td>PLZ</td>
-            <td>000000</td>
+            <td>
+              <input
+                v-model="zipcode"
+                class="user-settings__form-text-input"
+                type="text"
+                :disabled="notEditableAddress"
+              />
+            </td>
           </tr>
           <tr>
             <td>Ort</td>
-            <td>Musterhausen</td>
+            <td>
+              <input
+                v-model="city"
+                class="user-settings__form-text-input"
+                type="text"
+                :disabled="notEditableAddress"
+              />
+            </td>
           </tr>
         </tbody>
       </table>
@@ -102,11 +157,12 @@
         <thead>
           <tr class="mail-pw-wrapper">
             <th width="100%">
-              <label for="change-btn"
+              <label for="change-btn__mail-password"
                 >E-Mail und Passwort<input
                   type="button"
                   value=""
-                  id="change-btn"
+                  class="change-btn"
+                  id="change-btn__mail-password"
                 /><svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="100%"
@@ -153,10 +209,119 @@
       </table>
     </article>
   </section>
+  <ModalConfirmation
+    modal-message-screen="user-settings-confirmation"
+  ></ModalConfirmation>
 </template>
 
 <script>
-export default {};
+import ModalConfirmation from "@/components/main-component/expand-site-cards/ConfirmationExpandCard.vue";
+
+import { useGlobalStateStore } from "@/stores/useGlobalStateStore";
+import { useAuthenticationStore } from "@/stores/useAuthenticationStore.js";
+
+export default {
+  components: { ModalConfirmation },
+  data() {
+    return {
+      activeUser: "",
+      firstname: null,
+      lastname: null,
+      address: null,
+      zipcode: null,
+      city: null,
+      notEditableBasicInfos: true,
+      notEditableAddress: true,
+      notEditableMailPassword: true,
+      basicInfosChanged: false,
+      addressChanged: false,
+      mailPasswordChanged: false,
+    };
+  },
+  setup() {
+    const globalStateStore = useGlobalStateStore();
+    const authenticationStore = useAuthenticationStore();
+    return { globalStateStore, authenticationStore };
+  },
+  mounted() {
+    this.$watch(
+      () => this.authenticationStore.activeUser,
+      (activeUser) => {
+        this.activeUser = activeUser[0];
+        this.firstname = this.activeUser.firstname;
+        this.lastname = this.activeUser.lastname;
+        this.address = this.activeUser.address;
+        this.zipcode = this.activeUser.zipcode;
+        this.city = this.activeUser.city;
+        // After initialization data are changed, so set back to false
+        this.basicInfosChanged = false;
+        this.addressChanged = false;
+        this.mailPasswordChanged = false;
+      }
+    );
+  },
+  methods: {
+    editBasicInfo() {
+      this.notEditableBasicInfos = !this.notEditableBasicInfos;
+      if (this.basicInfosChanged) {
+        // Data set for the update function
+        let dataToUpdate = {
+          activeUser: this.activeUser.id,
+          firstname: this.firstname,
+          lastname: this.lastname,
+        };
+        // The update function
+        this.authenticationStore.updateCurrentUserData(dataToUpdate);
+        // set dataChange back to default
+        this.basicInfosChanged = false;
+      }
+    },
+    editAdress() {
+      this.notEditableAddress = !this.notEditableAddress;
+      if (this.addressChanged) {
+        // Data set for the update function
+        let dataToUpdate = {
+          activeUser: this.activeUser.id,
+          address: this.address,
+          zipcode: this.zipcode,
+          city: this.city,
+        };
+        // The update function
+        this.authenticationStore.updateCurrentUserAddress(dataToUpdate);
+        // set dataChange back to default
+        this.addressChanged = false;
+      }
+    },
+  },
+  // Watch if any data were changed by user
+  watch: {
+    firstname(newFirstName, oldFirstName) {
+      if (newFirstName !== oldFirstName) {
+        this.basicInfosChanged = true;
+      }
+    },
+    lastname(newLastName, oldLastName) {
+      if (newLastName !== oldLastName) {
+        this.basicInfosChanged = true;
+      }
+    },
+    address(newAddress, oldAddress) {
+      if (newAddress !== oldAddress) {
+        this.addressChanged = true;
+      }
+    },
+    zipcode(newZipcode, oldZipcode) {
+      if (newZipcode !== oldZipcode) {
+        this.addressChanged = true;
+      }
+    },
+    city(newCity, oldCity) {
+      if (newCity !== oldCity) {
+        this.addressChanged = true;
+      }
+    },
+  },
+};
 </script>
 
 <style scoped>
@@ -187,9 +352,7 @@ input[type="button"] {
   height: 0;
   top: -99999px;
 }
-#change-btn:active ~ svg {
-  fill: var(--check-checked);
-}
+
 /*===================================*/
 label {
   display: block;
@@ -203,7 +366,16 @@ label svg {
   height: var(--m-font);
   fill: var(--text-light);
 }
-
+/* Styling after edit button is pressed */
+.change-btn:active ~ svg {
+  fill: var(--check-checked);
+}
+.change-btn__active,
+.change-btn__active ~ svg {
+  fill: var(--secondary-color);
+  box-shadow: 0px 0px 15px var(--secondary-color);
+}
+/* end of edit button styling */
 .link-wrapper {
   display: block;
 
@@ -249,8 +421,26 @@ tr:nth-child(even) {
   border-bottom: var(--s-brd) solid var(--clr-brd-top);
   border-top: var(--s-brd) solid var(--clr-brd-top);
 }
-
 /*===============================================*/
+
+/* === Styling of Input Elements === */
+.user-settings__form-text-input,
+.user-settings__form-text-input:focus {
+  font-family: var(--def-font-style);
+  border: none;
+  color: var(--text-light);
+  font-weight: var(--f-weight-m);
+  text-align: right;
+  background: transparent;
+  outline-offset: var(--xs-pad);
+  outline-color: var(--shd-single-cards);
+}
+.user-settings__form-text-input:focus {
+  box-shadow: 0 0 20px 1px var(--shd-single-cards);
+  background: rgba(102, 100, 100, 0.08);
+  color: var(--text-mid);
+}
+/* === End of Styling of Input Elements === */
 
 .text-holder {
   display: block;

--- a/src/components/main-component/expand-site-cards/CarDataExpandCard.vue
+++ b/src/components/main-component/expand-site-cards/CarDataExpandCard.vue
@@ -10,8 +10,9 @@
         >
           <path
             d="m3.86 8.753 5.482 4.796c.646.566 1.658.106 1.658-.753V3.204a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506z"
-          /></svg
-      ></a>
+          />
+        </svg>
+      </a>
       <h2 class="menue-expand__site-header">Fahrzeug</h2>
     </header>
     <div class="menue-expand__inner-wrapper">
@@ -105,10 +106,10 @@ header h2 {
   height: 90.5vh;
   margin-top: 0.2rem;
   margin-inline: auto;
+  padding-top: 1rem;
   padding-inline: var(--s-pad);
   border-radius: var(--s-brd-rad) var(--s-brd-rad) 0 0;
   background: var(--bg-content);
-
   overflow: scroll;
 }
 </style>

--- a/src/components/main-component/expand-site-cards/ConfirmationExpandCard.vue
+++ b/src/components/main-component/expand-site-cards/ConfirmationExpandCard.vue
@@ -7,17 +7,23 @@
     id="booking-confirmation"
   >
     <article class="question-card">
-      <DeleteLogCard deleteLogProfil="booking-confirmation" />
+      <DeleteLogCard :deleteLogProfil="modalMessageScreen" />
     </article>
   </section>
 </template>
 
 <script scoped>
 import DeleteLogCard from "@/components/main-component/expand-menu-components/DeleteLogQuestion.vue";
-import { useGlobalStateStore } from "@/stores/useGlobalStateStore"; 
+import { useGlobalStateStore } from "@/stores/useGlobalStateStore";
 import { watch } from "vue";
 
 export default {
+  props: {
+    modalMessageScreen: {
+      type: String,
+      default: "booking-confirmation",
+    },
+  },
   components: {
     DeleteLogCard,
   },
@@ -29,16 +35,16 @@ export default {
   setup() {
     // Initialize the store at the begining
     const globalStateStore = useGlobalStateStore();
-    return { globalStateStore};
+    return { globalStateStore };
   },
   mounted() {
     // This watch must be imported and can be used to look for changes in the pinia store.
     watch(
       () => this.globalStateStore.translateCard,
       (translateValue) => {
-        this.changePage = translateValue
+        this.changePage = translateValue;
       }
-    )
+    );
   },
 };
 </script>
@@ -58,7 +64,6 @@ section:target {
   top: 0%;
   left: 0%;
   translate: 0% 0;
-  /* translate: -100% 0; */
   transition: 0s;
   display: grid;
   place-content: center;

--- a/src/components/main-component/expand-site-cards/UserDataExpandCard.vue
+++ b/src/components/main-component/expand-site-cards/UserDataExpandCard.vue
@@ -107,9 +107,9 @@ header h2 {
   margin-top: 0.2rem;
   margin-inline: auto;
   padding-inline: var(--s-pad);
+  padding-top: 1rem;
   border-radius: var(--s-brd-rad) var(--s-brd-rad) 0 0;
   background: var(--bg-content);
-
   overflow: scroll;
 }
 </style>

--- a/src/stores/useAuthenticationStore.js
+++ b/src/stores/useAuthenticationStore.js
@@ -48,5 +48,34 @@ export const useAuthenticationStore = defineStore("authentication", {
         alert(error.message);
       }
     },
+    async updateCurrentUserData(dataToUpdate) {
+      try {
+        const { error } = await supabase
+          .from("users")
+          .update({
+            firstname: dataToUpdate.firstname,
+            lastname: dataToUpdate.lastname,
+          })
+          .eq("id", dataToUpdate.activeUser);
+        if (error) throw error;
+      } catch (error) {
+        alert(error.message);
+      }
+    },
+    async updateCurrentUserAddress(dataToUpdate) {
+      try {
+        const { error } = await supabase
+          .from("users")
+          .update({
+            address: dataToUpdate.address,
+            zipcode: dataToUpdate.zipcode,
+            city: dataToUpdate.city,
+          })
+          .eq("id", dataToUpdate.activeUser);
+        if (error) throw error;
+      } catch (error) {
+        alert(error.message);
+      }
+    },
   },
 });

--- a/src/stores/useCarStore.js
+++ b/src/stores/useCarStore.js
@@ -5,6 +5,8 @@ export const useCarStore = defineStore("car", {
   state: () => ({
     cars: [],
     userCar: [],
+    gearData: null,
+    insuranceData: null,
   }),
 
   actions: {
@@ -23,11 +25,85 @@ export const useCarStore = defineStore("car", {
     },
     async getUserCar(activeUser) {
       try {
-        let { data, error } = await supabase.from("cars").select().eq("user_id", activeUser);
+        let { data, error } = await supabase
+          .from("cars")
+          .select()
+          .eq("user_id", activeUser);
 
         if (error) throw error;
         if (data) {
           this.userCar = data;
+        }
+      } catch (error) {
+        alert(error.message);
+      }
+    },
+    async updateCarInsuranceInfo(dataToUpdate) {
+      try {
+        const { error } = await supabase
+          .from("cars")
+          .update({
+            insurance_no: dataToUpdate.insurance_no,
+            insurance_type: dataToUpdate.insurance_type,
+          })
+          .eq("id", dataToUpdate.activeUserCarID);
+        if (error) throw error;
+      } catch (error) {
+        alert(error.message);
+      }
+    },
+    async updateCarInfo(dataToUpdate) {
+      try {
+        const { error } = await supabase
+          .from("cars")
+          .update({
+            car_license_plate: dataToUpdate.licensePlate,
+            year_of_construction: dataToUpdate.manufactureYear,
+            trunk_volume_in_liters: dataToUpdate.trunkSize,
+          })
+          .eq("id", dataToUpdate.activeUserCarID);
+        if (error) throw error;
+      } catch (error) {
+        alert(error.message);
+      }
+    },
+    async updateCarPerformanceInfo(dataToUpdate) {
+      try {
+        const { error } = await supabase
+          .from("cars")
+          .update({
+            gear: dataToUpdate.gearBox,
+            fuel_consume_per_km: dataToUpdate.carConsumption,
+            kw: dataToUpdate.horsePower,
+            max_speed: dataToUpdate.topSpeed,
+          })
+          .eq("id", dataToUpdate.activeUserCarID);
+        if (error) throw error;
+      } catch (error) {
+        alert(error.message);
+      }
+    },
+    async getGearData() {
+      try {
+        const { data, error } = await supabase.rpc("get_gear");
+
+        if (error) throw error;
+
+        if (data) {
+          this.gearData = data;
+        }
+      } catch (error) {
+        alert(error.message);
+      }
+    },
+    async getInsuranceData() {
+      try {
+        const { data, error } = await supabase.rpc("get_insurance");
+
+        if (error) throw error;
+
+        if (data) {
+          this.insuranceData = data;
         }
       } catch (error) {
         alert(error.message);

--- a/src/views/MainPageView.vue
+++ b/src/views/MainPageView.vue
@@ -246,6 +246,7 @@ export default {
   padding-top: 2rem;
   overflow: scroll;
   position: fixed;
+  padding-bottom: 2.5rem;
 }
 .main-page-style {
   background: var(--clr-bg);

--- a/src/views/UserProfileView.vue
+++ b/src/views/UserProfileView.vue
@@ -228,7 +228,7 @@ import InputText from "@/components/input-elements/InputText.vue";
 
 import BookingCalendarExpandCard from "@/components/main-component/expand-site-cards/BookingCalendarExpandCard.vue";
 import BookingExpandCard from "@/components/main-component/expand-site-cards/BookingExpandCard.vue";
-import BookingConfirmation from "@/components/main-component/expand-site-cards/BookingConfirmationExpandCard.vue";
+import BookingConfirmation from "@/components/main-component/expand-site-cards/ConfirmationExpandCard.vue";
 
 import { useGlobalStateStore } from "@/stores/useGlobalStateStore";
 import { useAuthenticationStore } from "@/stores/useAuthenticationStore";


### PR DESCRIPTION
Resolves #303 

<details><summary>Details</summary>
<p>

- [x] Die Platzhalter in den Profile Settings sollten den aktuellen User abbilden
- [x] Die Daten des Users sollen vom User bearbeitet und updatebar sein.

- [x] Settings Karten können nun für die Bearbeitung aktiviert werden und speichern nur die veränderten Daten.
![image](https://github.com/danielkull/capp/assets/119632155/be56e83d-13c6-4e23-bc85-964c36300401)

- [x] Abstand der letzten Small Car Card zur Navbar in MainView vergrößert
![image](https://github.com/danielkull/capp/assets/119632155/ee96e80f-f704-4485-a4cf-62aa992bb764)
- [x] Abstand der ersten Settings Card zum Header in den User und Car Settings vergrößert
![image](https://github.com/danielkull/capp/assets/119632155/6b27a405-9381-44a7-801d-00b809887a9b)

</p>
</details> 